### PR TITLE
feat: Add push notification configuration management for tasks

### DIFF
--- a/adk/generated_types.go
+++ b/adk/generated_types.go
@@ -44,6 +44,7 @@ type AgentCapabilities struct {
 // - Default modalities/content types supported by the agent.
 // - Authentication requirements
 type AgentCard struct {
+	AdditionalInterfaces              []AgentInterface          `json:"additionalInterfaces,omitempty"`
 	Capabilities                      AgentCapabilities         `json:"capabilities"`
 	DefaultInputModes                 []string                  `json:"defaultInputModes"`
 	DefaultOutputModes                []string                  `json:"defaultOutputModes"`
@@ -51,6 +52,7 @@ type AgentCard struct {
 	DocumentationURL                  *string                   `json:"documentationUrl,omitempty"`
 	IconURL                           *string                   `json:"iconUrl,omitempty"`
 	Name                              string                    `json:"name"`
+	PreferredTransport                *string                   `json:"preferredTransport,omitempty"`
 	Provider                          *AgentProvider            `json:"provider,omitempty"`
 	Security                          []map[string][]string     `json:"security,omitempty"`
 	SecuritySchemes                   map[string]SecurityScheme `json:"securitySchemes,omitempty"`
@@ -66,6 +68,13 @@ type AgentExtension struct {
 	Params      map[string]interface{} `json:"params,omitempty"`
 	Required    *bool                  `json:"required,omitempty"`
 	URI         string                 `json:"uri"`
+}
+
+// AgentInterface provides a declaration of a combination of the
+// target url and the supported transport to interact with the agent.
+type AgentInterface struct {
+	Transport string `json:"transport"`
+	URL       string `json:"url"`
 }
 
 // Represents the service provider of an agent.
@@ -142,6 +151,31 @@ type DataPart struct {
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
+// Parameters for removing pushNotificationConfiguration associated with a Task
+type DeleteTaskPushNotificationConfigParams struct {
+	ID                       string                 `json:"id"`
+	Metadata                 map[string]interface{} `json:"metadata,omitempty"`
+	PushNotificationConfigID string                 `json:"pushNotificationConfigId"`
+}
+
+// JSON-RPC request model for the 'tasks/pushNotificationConfig/delete' method.
+type DeleteTaskPushNotificationConfigRequest struct {
+	ID      interface{}                            `json:"id"`
+	JSONRPC string                                 `json:"jsonrpc"`
+	Method  string                                 `json:"method"`
+	Params  DeleteTaskPushNotificationConfigParams `json:"params"`
+}
+
+// JSON-RPC response for the 'tasks/pushNotificationConfig/delete' method.
+type DeleteTaskPushNotificationConfigResponse interface{}
+
+// JSON-RPC success response model for the 'tasks/pushNotificationConfig/delete' method.
+type DeleteTaskPushNotificationConfigSuccessResponse struct {
+	ID      interface{} `json:"id"`
+	JSONRPC string      `json:"jsonrpc"`
+	Result  interface{} `json:"result"`
+}
+
 // Represents the base entity for FileParts
 type FileBase struct {
 	MIMEType *string `json:"mimeType,omitempty"`
@@ -169,12 +203,19 @@ type FileWithUri struct {
 	URI      string  `json:"uri"`
 }
 
+// Parameters for fetching a pushNotificationConfiguration associated with a Task
+type GetTaskPushNotificationConfigParams struct {
+	ID                       string                 `json:"id"`
+	Metadata                 map[string]interface{} `json:"metadata,omitempty"`
+	PushNotificationConfigID *string                `json:"pushNotificationConfigId,omitempty"`
+}
+
 // JSON-RPC request model for the 'tasks/pushNotificationConfig/get' method.
 type GetTaskPushNotificationConfigRequest struct {
-	ID      interface{}  `json:"id"`
-	JSONRPC string       `json:"jsonrpc"`
-	Method  string       `json:"method"`
-	Params  TaskIdParams `json:"params"`
+	ID      interface{} `json:"id"`
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
 }
 
 // JSON-RPC response for the 'tasks/pushNotificationConfig/set' method.
@@ -292,6 +333,30 @@ type JSONRPCSuccessResponse struct {
 	ID      interface{} `json:"id"`
 	JSONRPC string      `json:"jsonrpc"`
 	Result  interface{} `json:"result"`
+}
+
+// Parameters for getting list of pushNotificationConfigurations associated with a Task
+type ListTaskPushNotificationConfigParams struct {
+	ID       string                 `json:"id"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// JSON-RPC request model for the 'tasks/pushNotificationConfig/list' method.
+type ListTaskPushNotificationConfigRequest struct {
+	ID      interface{}                          `json:"id"`
+	JSONRPC string                               `json:"jsonrpc"`
+	Method  string                               `json:"method"`
+	Params  ListTaskPushNotificationConfigParams `json:"params"`
+}
+
+// JSON-RPC response for the 'tasks/pushNotificationConfig/list' method.
+type ListTaskPushNotificationConfigResponse interface{}
+
+// JSON-RPC success response model for the 'tasks/pushNotificationConfig/list' method.
+type ListTaskPushNotificationConfigSuccessResponse struct {
+	ID      interface{}                  `json:"id"`
+	JSONRPC string                       `json:"jsonrpc"`
+	Result  []TaskPushNotificationConfig `json:"result"`
 }
 
 // JSON-RPC request model for the 'tasks/list' method.

--- a/adk/server/mocks/fake_task_manager.go
+++ b/adk/server/mocks/fake_task_manager.go
@@ -38,6 +38,17 @@ type FakeTaskManager struct {
 	createTaskReturnsOnCall map[int]struct {
 		result1 *adk.Task
 	}
+	DeleteTaskPushNotificationConfigStub        func(adk.DeleteTaskPushNotificationConfigParams) error
+	deleteTaskPushNotificationConfigMutex       sync.RWMutex
+	deleteTaskPushNotificationConfigArgsForCall []struct {
+		arg1 adk.DeleteTaskPushNotificationConfigParams
+	}
+	deleteTaskPushNotificationConfigReturns struct {
+		result1 error
+	}
+	deleteTaskPushNotificationConfigReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetConversationHistoryStub        func(string) []adk.Message
 	getConversationHistoryMutex       sync.RWMutex
 	getConversationHistoryArgsForCall []struct {
@@ -61,6 +72,32 @@ type FakeTaskManager struct {
 	getTaskReturnsOnCall map[int]struct {
 		result1 *adk.Task
 		result2 bool
+	}
+	GetTaskPushNotificationConfigStub        func(adk.GetTaskPushNotificationConfigParams) (*adk.TaskPushNotificationConfig, error)
+	getTaskPushNotificationConfigMutex       sync.RWMutex
+	getTaskPushNotificationConfigArgsForCall []struct {
+		arg1 adk.GetTaskPushNotificationConfigParams
+	}
+	getTaskPushNotificationConfigReturns struct {
+		result1 *adk.TaskPushNotificationConfig
+		result2 error
+	}
+	getTaskPushNotificationConfigReturnsOnCall map[int]struct {
+		result1 *adk.TaskPushNotificationConfig
+		result2 error
+	}
+	ListTaskPushNotificationConfigsStub        func(adk.ListTaskPushNotificationConfigParams) ([]adk.TaskPushNotificationConfig, error)
+	listTaskPushNotificationConfigsMutex       sync.RWMutex
+	listTaskPushNotificationConfigsArgsForCall []struct {
+		arg1 adk.ListTaskPushNotificationConfigParams
+	}
+	listTaskPushNotificationConfigsReturns struct {
+		result1 []adk.TaskPushNotificationConfig
+		result2 error
+	}
+	listTaskPushNotificationConfigsReturnsOnCall map[int]struct {
+		result1 []adk.TaskPushNotificationConfig
+		result2 error
 	}
 	ListTasksStub        func(adk.TaskListParams) (*adk.TaskList, error)
 	listTasksMutex       sync.RWMutex
@@ -88,6 +125,19 @@ type FakeTaskManager struct {
 	}
 	pollTaskStatusReturnsOnCall map[int]struct {
 		result1 *adk.Task
+		result2 error
+	}
+	SetTaskPushNotificationConfigStub        func(adk.TaskPushNotificationConfig) (*adk.TaskPushNotificationConfig, error)
+	setTaskPushNotificationConfigMutex       sync.RWMutex
+	setTaskPushNotificationConfigArgsForCall []struct {
+		arg1 adk.TaskPushNotificationConfig
+	}
+	setTaskPushNotificationConfigReturns struct {
+		result1 *adk.TaskPushNotificationConfig
+		result2 error
+	}
+	setTaskPushNotificationConfigReturnsOnCall map[int]struct {
+		result1 *adk.TaskPushNotificationConfig
 		result2 error
 	}
 	UpdateConversationHistoryStub        func(string, []adk.Message)
@@ -261,6 +311,67 @@ func (fake *FakeTaskManager) CreateTaskReturnsOnCall(i int, result1 *adk.Task) {
 	}{result1}
 }
 
+func (fake *FakeTaskManager) DeleteTaskPushNotificationConfig(arg1 adk.DeleteTaskPushNotificationConfigParams) error {
+	fake.deleteTaskPushNotificationConfigMutex.Lock()
+	ret, specificReturn := fake.deleteTaskPushNotificationConfigReturnsOnCall[len(fake.deleteTaskPushNotificationConfigArgsForCall)]
+	fake.deleteTaskPushNotificationConfigArgsForCall = append(fake.deleteTaskPushNotificationConfigArgsForCall, struct {
+		arg1 adk.DeleteTaskPushNotificationConfigParams
+	}{arg1})
+	stub := fake.DeleteTaskPushNotificationConfigStub
+	fakeReturns := fake.deleteTaskPushNotificationConfigReturns
+	fake.recordInvocation("DeleteTaskPushNotificationConfig", []interface{}{arg1})
+	fake.deleteTaskPushNotificationConfigMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeTaskManager) DeleteTaskPushNotificationConfigCallCount() int {
+	fake.deleteTaskPushNotificationConfigMutex.RLock()
+	defer fake.deleteTaskPushNotificationConfigMutex.RUnlock()
+	return len(fake.deleteTaskPushNotificationConfigArgsForCall)
+}
+
+func (fake *FakeTaskManager) DeleteTaskPushNotificationConfigCalls(stub func(adk.DeleteTaskPushNotificationConfigParams) error) {
+	fake.deleteTaskPushNotificationConfigMutex.Lock()
+	defer fake.deleteTaskPushNotificationConfigMutex.Unlock()
+	fake.DeleteTaskPushNotificationConfigStub = stub
+}
+
+func (fake *FakeTaskManager) DeleteTaskPushNotificationConfigArgsForCall(i int) adk.DeleteTaskPushNotificationConfigParams {
+	fake.deleteTaskPushNotificationConfigMutex.RLock()
+	defer fake.deleteTaskPushNotificationConfigMutex.RUnlock()
+	argsForCall := fake.deleteTaskPushNotificationConfigArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTaskManager) DeleteTaskPushNotificationConfigReturns(result1 error) {
+	fake.deleteTaskPushNotificationConfigMutex.Lock()
+	defer fake.deleteTaskPushNotificationConfigMutex.Unlock()
+	fake.DeleteTaskPushNotificationConfigStub = nil
+	fake.deleteTaskPushNotificationConfigReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeTaskManager) DeleteTaskPushNotificationConfigReturnsOnCall(i int, result1 error) {
+	fake.deleteTaskPushNotificationConfigMutex.Lock()
+	defer fake.deleteTaskPushNotificationConfigMutex.Unlock()
+	fake.DeleteTaskPushNotificationConfigStub = nil
+	if fake.deleteTaskPushNotificationConfigReturnsOnCall == nil {
+		fake.deleteTaskPushNotificationConfigReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteTaskPushNotificationConfigReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeTaskManager) GetConversationHistory(arg1 string) []adk.Message {
 	fake.getConversationHistoryMutex.Lock()
 	ret, specificReturn := fake.getConversationHistoryReturnsOnCall[len(fake.getConversationHistoryArgsForCall)]
@@ -383,6 +494,134 @@ func (fake *FakeTaskManager) GetTaskReturnsOnCall(i int, result1 *adk.Task, resu
 	fake.getTaskReturnsOnCall[i] = struct {
 		result1 *adk.Task
 		result2 bool
+	}{result1, result2}
+}
+
+func (fake *FakeTaskManager) GetTaskPushNotificationConfig(arg1 adk.GetTaskPushNotificationConfigParams) (*adk.TaskPushNotificationConfig, error) {
+	fake.getTaskPushNotificationConfigMutex.Lock()
+	ret, specificReturn := fake.getTaskPushNotificationConfigReturnsOnCall[len(fake.getTaskPushNotificationConfigArgsForCall)]
+	fake.getTaskPushNotificationConfigArgsForCall = append(fake.getTaskPushNotificationConfigArgsForCall, struct {
+		arg1 adk.GetTaskPushNotificationConfigParams
+	}{arg1})
+	stub := fake.GetTaskPushNotificationConfigStub
+	fakeReturns := fake.getTaskPushNotificationConfigReturns
+	fake.recordInvocation("GetTaskPushNotificationConfig", []interface{}{arg1})
+	fake.getTaskPushNotificationConfigMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTaskManager) GetTaskPushNotificationConfigCallCount() int {
+	fake.getTaskPushNotificationConfigMutex.RLock()
+	defer fake.getTaskPushNotificationConfigMutex.RUnlock()
+	return len(fake.getTaskPushNotificationConfigArgsForCall)
+}
+
+func (fake *FakeTaskManager) GetTaskPushNotificationConfigCalls(stub func(adk.GetTaskPushNotificationConfigParams) (*adk.TaskPushNotificationConfig, error)) {
+	fake.getTaskPushNotificationConfigMutex.Lock()
+	defer fake.getTaskPushNotificationConfigMutex.Unlock()
+	fake.GetTaskPushNotificationConfigStub = stub
+}
+
+func (fake *FakeTaskManager) GetTaskPushNotificationConfigArgsForCall(i int) adk.GetTaskPushNotificationConfigParams {
+	fake.getTaskPushNotificationConfigMutex.RLock()
+	defer fake.getTaskPushNotificationConfigMutex.RUnlock()
+	argsForCall := fake.getTaskPushNotificationConfigArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTaskManager) GetTaskPushNotificationConfigReturns(result1 *adk.TaskPushNotificationConfig, result2 error) {
+	fake.getTaskPushNotificationConfigMutex.Lock()
+	defer fake.getTaskPushNotificationConfigMutex.Unlock()
+	fake.GetTaskPushNotificationConfigStub = nil
+	fake.getTaskPushNotificationConfigReturns = struct {
+		result1 *adk.TaskPushNotificationConfig
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTaskManager) GetTaskPushNotificationConfigReturnsOnCall(i int, result1 *adk.TaskPushNotificationConfig, result2 error) {
+	fake.getTaskPushNotificationConfigMutex.Lock()
+	defer fake.getTaskPushNotificationConfigMutex.Unlock()
+	fake.GetTaskPushNotificationConfigStub = nil
+	if fake.getTaskPushNotificationConfigReturnsOnCall == nil {
+		fake.getTaskPushNotificationConfigReturnsOnCall = make(map[int]struct {
+			result1 *adk.TaskPushNotificationConfig
+			result2 error
+		})
+	}
+	fake.getTaskPushNotificationConfigReturnsOnCall[i] = struct {
+		result1 *adk.TaskPushNotificationConfig
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTaskManager) ListTaskPushNotificationConfigs(arg1 adk.ListTaskPushNotificationConfigParams) ([]adk.TaskPushNotificationConfig, error) {
+	fake.listTaskPushNotificationConfigsMutex.Lock()
+	ret, specificReturn := fake.listTaskPushNotificationConfigsReturnsOnCall[len(fake.listTaskPushNotificationConfigsArgsForCall)]
+	fake.listTaskPushNotificationConfigsArgsForCall = append(fake.listTaskPushNotificationConfigsArgsForCall, struct {
+		arg1 adk.ListTaskPushNotificationConfigParams
+	}{arg1})
+	stub := fake.ListTaskPushNotificationConfigsStub
+	fakeReturns := fake.listTaskPushNotificationConfigsReturns
+	fake.recordInvocation("ListTaskPushNotificationConfigs", []interface{}{arg1})
+	fake.listTaskPushNotificationConfigsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTaskManager) ListTaskPushNotificationConfigsCallCount() int {
+	fake.listTaskPushNotificationConfigsMutex.RLock()
+	defer fake.listTaskPushNotificationConfigsMutex.RUnlock()
+	return len(fake.listTaskPushNotificationConfigsArgsForCall)
+}
+
+func (fake *FakeTaskManager) ListTaskPushNotificationConfigsCalls(stub func(adk.ListTaskPushNotificationConfigParams) ([]adk.TaskPushNotificationConfig, error)) {
+	fake.listTaskPushNotificationConfigsMutex.Lock()
+	defer fake.listTaskPushNotificationConfigsMutex.Unlock()
+	fake.ListTaskPushNotificationConfigsStub = stub
+}
+
+func (fake *FakeTaskManager) ListTaskPushNotificationConfigsArgsForCall(i int) adk.ListTaskPushNotificationConfigParams {
+	fake.listTaskPushNotificationConfigsMutex.RLock()
+	defer fake.listTaskPushNotificationConfigsMutex.RUnlock()
+	argsForCall := fake.listTaskPushNotificationConfigsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTaskManager) ListTaskPushNotificationConfigsReturns(result1 []adk.TaskPushNotificationConfig, result2 error) {
+	fake.listTaskPushNotificationConfigsMutex.Lock()
+	defer fake.listTaskPushNotificationConfigsMutex.Unlock()
+	fake.ListTaskPushNotificationConfigsStub = nil
+	fake.listTaskPushNotificationConfigsReturns = struct {
+		result1 []adk.TaskPushNotificationConfig
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTaskManager) ListTaskPushNotificationConfigsReturnsOnCall(i int, result1 []adk.TaskPushNotificationConfig, result2 error) {
+	fake.listTaskPushNotificationConfigsMutex.Lock()
+	defer fake.listTaskPushNotificationConfigsMutex.Unlock()
+	fake.ListTaskPushNotificationConfigsStub = nil
+	if fake.listTaskPushNotificationConfigsReturnsOnCall == nil {
+		fake.listTaskPushNotificationConfigsReturnsOnCall = make(map[int]struct {
+			result1 []adk.TaskPushNotificationConfig
+			result2 error
+		})
+	}
+	fake.listTaskPushNotificationConfigsReturnsOnCall[i] = struct {
+		result1 []adk.TaskPushNotificationConfig
+		result2 error
 	}{result1, result2}
 }
 
@@ -516,6 +755,70 @@ func (fake *FakeTaskManager) PollTaskStatusReturnsOnCall(i int, result1 *adk.Tas
 	}{result1, result2}
 }
 
+func (fake *FakeTaskManager) SetTaskPushNotificationConfig(arg1 adk.TaskPushNotificationConfig) (*adk.TaskPushNotificationConfig, error) {
+	fake.setTaskPushNotificationConfigMutex.Lock()
+	ret, specificReturn := fake.setTaskPushNotificationConfigReturnsOnCall[len(fake.setTaskPushNotificationConfigArgsForCall)]
+	fake.setTaskPushNotificationConfigArgsForCall = append(fake.setTaskPushNotificationConfigArgsForCall, struct {
+		arg1 adk.TaskPushNotificationConfig
+	}{arg1})
+	stub := fake.SetTaskPushNotificationConfigStub
+	fakeReturns := fake.setTaskPushNotificationConfigReturns
+	fake.recordInvocation("SetTaskPushNotificationConfig", []interface{}{arg1})
+	fake.setTaskPushNotificationConfigMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTaskManager) SetTaskPushNotificationConfigCallCount() int {
+	fake.setTaskPushNotificationConfigMutex.RLock()
+	defer fake.setTaskPushNotificationConfigMutex.RUnlock()
+	return len(fake.setTaskPushNotificationConfigArgsForCall)
+}
+
+func (fake *FakeTaskManager) SetTaskPushNotificationConfigCalls(stub func(adk.TaskPushNotificationConfig) (*adk.TaskPushNotificationConfig, error)) {
+	fake.setTaskPushNotificationConfigMutex.Lock()
+	defer fake.setTaskPushNotificationConfigMutex.Unlock()
+	fake.SetTaskPushNotificationConfigStub = stub
+}
+
+func (fake *FakeTaskManager) SetTaskPushNotificationConfigArgsForCall(i int) adk.TaskPushNotificationConfig {
+	fake.setTaskPushNotificationConfigMutex.RLock()
+	defer fake.setTaskPushNotificationConfigMutex.RUnlock()
+	argsForCall := fake.setTaskPushNotificationConfigArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTaskManager) SetTaskPushNotificationConfigReturns(result1 *adk.TaskPushNotificationConfig, result2 error) {
+	fake.setTaskPushNotificationConfigMutex.Lock()
+	defer fake.setTaskPushNotificationConfigMutex.Unlock()
+	fake.SetTaskPushNotificationConfigStub = nil
+	fake.setTaskPushNotificationConfigReturns = struct {
+		result1 *adk.TaskPushNotificationConfig
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTaskManager) SetTaskPushNotificationConfigReturnsOnCall(i int, result1 *adk.TaskPushNotificationConfig, result2 error) {
+	fake.setTaskPushNotificationConfigMutex.Lock()
+	defer fake.setTaskPushNotificationConfigMutex.Unlock()
+	fake.SetTaskPushNotificationConfigStub = nil
+	if fake.setTaskPushNotificationConfigReturnsOnCall == nil {
+		fake.setTaskPushNotificationConfigReturnsOnCall = make(map[int]struct {
+			result1 *adk.TaskPushNotificationConfig
+			result2 error
+		})
+	}
+	fake.setTaskPushNotificationConfigReturnsOnCall[i] = struct {
+		result1 *adk.TaskPushNotificationConfig
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTaskManager) UpdateConversationHistory(arg1 string, arg2 []adk.Message) {
 	var arg2Copy []adk.Message
 	if arg2 != nil {
@@ -626,14 +929,22 @@ func (fake *FakeTaskManager) Invocations() map[string][][]interface{} {
 	defer fake.cleanupCompletedTasksMutex.RUnlock()
 	fake.createTaskMutex.RLock()
 	defer fake.createTaskMutex.RUnlock()
+	fake.deleteTaskPushNotificationConfigMutex.RLock()
+	defer fake.deleteTaskPushNotificationConfigMutex.RUnlock()
 	fake.getConversationHistoryMutex.RLock()
 	defer fake.getConversationHistoryMutex.RUnlock()
 	fake.getTaskMutex.RLock()
 	defer fake.getTaskMutex.RUnlock()
+	fake.getTaskPushNotificationConfigMutex.RLock()
+	defer fake.getTaskPushNotificationConfigMutex.RUnlock()
+	fake.listTaskPushNotificationConfigsMutex.RLock()
+	defer fake.listTaskPushNotificationConfigsMutex.RUnlock()
 	fake.listTasksMutex.RLock()
 	defer fake.listTasksMutex.RUnlock()
 	fake.pollTaskStatusMutex.RLock()
 	defer fake.pollTaskStatusMutex.RUnlock()
+	fake.setTaskPushNotificationConfigMutex.RLock()
+	defer fake.setTaskPushNotificationConfigMutex.RUnlock()
 	fake.updateConversationHistoryMutex.RLock()
 	defer fake.updateConversationHistoryMutex.RUnlock()
 	fake.updateTaskMutex.RLock()

--- a/adk/server/push_notification_sender.go
+++ b/adk/server/push_notification_sender.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	adk "github.com/inference-gateway/a2a/adk"
+	zap "go.uber.org/zap"
+)
+
+// PushNotificationSender handles sending push notifications
+type PushNotificationSender interface {
+	SendTaskUpdate(ctx context.Context, config adk.PushNotificationConfig, task *adk.Task) error
+}
+
+// HTTPPushNotificationSender implements push notifications via HTTP webhooks
+type HTTPPushNotificationSender struct {
+	httpClient *http.Client
+	logger     *zap.Logger
+}
+
+// NewHTTPPushNotificationSender creates a new HTTP-based push notification sender
+func NewHTTPPushNotificationSender(logger *zap.Logger) *HTTPPushNotificationSender {
+	return &HTTPPushNotificationSender{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger,
+	}
+}
+
+// TaskUpdateNotification represents the payload sent to webhook URLs
+type TaskUpdateNotification struct {
+	Type      string    `json:"type"`
+	TaskID    string    `json:"taskId"`
+	State     string    `json:"state"`
+	Timestamp string    `json:"timestamp"`
+	Task      *adk.Task `json:"task,omitempty"`
+}
+
+// SendTaskUpdate sends a push notification about a task update
+func (s *HTTPPushNotificationSender) SendTaskUpdate(ctx context.Context, config adk.PushNotificationConfig, task *adk.Task) error {
+	notification := TaskUpdateNotification{
+		Type:      "task_update",
+		TaskID:    task.ID,
+		State:     string(task.Status.State),
+		Timestamp: *task.Status.Timestamp,
+		Task:      task,
+	}
+
+	payload, err := json.Marshal(notification)
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", config.URL, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "A2A-Server/1.0")
+
+	if config.Token != nil && *config.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+*config.Token)
+	}
+
+	if config.Authentication != nil {
+		for _, scheme := range config.Authentication.Schemes {
+			switch scheme {
+			case "bearer":
+				if config.Authentication.Credentials != nil {
+					req.Header.Set("Authorization", "Bearer "+*config.Authentication.Credentials)
+				}
+			case "basic":
+				if config.Authentication.Credentials != nil {
+					req.Header.Set("Authorization", "Basic "+*config.Authentication.Credentials)
+				}
+			}
+		}
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send push notification: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			s.logger.Warn("failed to close response body", zap.Error(closeErr))
+		}
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("push notification webhook returned status %d", resp.StatusCode)
+	}
+
+	s.logger.Info("push notification sent successfully",
+		zap.String("task_id", task.ID),
+		zap.String("webhook_url", config.URL),
+		zap.String("state", string(task.Status.State)),
+		zap.Int("status_code", resp.StatusCode))
+
+	return nil
+}

--- a/schema.yaml
+++ b/schema.yaml
@@ -23,6 +23,8 @@ definitions:
       - $ref: '#/definitions/SetTaskPushNotificationConfigRequest'
       - $ref: '#/definitions/GetTaskPushNotificationConfigRequest'
       - $ref: '#/definitions/TaskResubscriptionRequest'
+      - $ref: '#/definitions/ListTaskPushNotificationConfigRequest'
+      - $ref: '#/definitions/DeleteTaskPushNotificationConfigRequest'
     description: A2A supported request types
   APIKeySecurityScheme:
     description: API Key security scheme.
@@ -74,6 +76,13 @@ definitions:
       - Default modalities/content types supported by the agent.
       - Authentication requirements
     properties:
+      additionalInterfaces:
+        description: |-
+          Announcement of additional supported transports. Client can use any of
+          the supported transports.
+        items:
+          $ref: '#/definitions/AgentInterface'
+        type: array
       capabilities:
         $ref: '#/definitions/AgentCapabilities'
         description: Optional capabilities supported by the agent.
@@ -103,6 +112,9 @@ definitions:
       name:
         description: Human readable name of the agent.
         type: string
+      preferredTransport:
+        description: The transport of the preferred endpoint. If empty, defaults to JSONRPC.
+        type: string
       provider:
         $ref: '#/definitions/AgentProvider'
         description: The service provider of the agent
@@ -131,7 +143,9 @@ definitions:
           Defaults to false if not specified.
         type: boolean
       url:
-        description: A URL to the address the agent is hosted at.
+        description: |-
+          A URL to the address the agent is hosted at. This represents the
+          preferred endpoint as declared by the agent.
         type: string
       version:
         description: The version of the agent - format is up to the provider.
@@ -164,6 +178,23 @@ definitions:
         type: string
     required:
       - uri
+    type: object
+  AgentInterface:
+    description: |-
+      AgentInterface provides a declaration of a combination of the
+      target url and the supported transport to interact with the agent.
+    properties:
+      transport:
+        description: |-
+          The transport supported this url. This is an open form string, to be
+          easily extended for many transport protocols. The core ones officially
+          supported are JSONRPC, GRPC and HTTP+JSON.
+        type: string
+      url:
+        type: string
+    required:
+      - transport
+      - url
     type: object
   AgentProvider:
     description: Represents the service provider of an agent.
@@ -400,6 +431,76 @@ definitions:
       - data
       - kind
     type: object
+  DeleteTaskPushNotificationConfigParams:
+    description: Parameters for removing pushNotificationConfiguration associated with a Task
+    properties:
+      id:
+        description: Task id.
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      pushNotificationConfigId:
+        type: string
+    required:
+      - id
+      - pushNotificationConfigId
+    type: object
+  DeleteTaskPushNotificationConfigRequest:
+    description: JSON-RPC request model for the 'tasks/pushNotificationConfig/delete' method.
+    properties:
+      id:
+        description: |-
+          An identifier established by the Client that MUST contain a String, Number.
+          Numbers SHOULD NOT contain fractional parts.
+        type:
+          - string
+          - integer
+      jsonrpc:
+        const: '2.0'
+        description: Specifies the version of the JSON-RPC protocol. MUST be exactly "2.0".
+        type: string
+      method:
+        const: tasks/pushNotificationConfig/delete
+        description: A String containing the name of the method to be invoked.
+        type: string
+      params:
+        $ref: '#/definitions/DeleteTaskPushNotificationConfigParams'
+        description: A Structured value that holds the parameter values to be used during the invocation of the method.
+    required:
+      - id
+      - jsonrpc
+      - method
+      - params
+    type: object
+  DeleteTaskPushNotificationConfigResponse:
+    anyOf:
+      - $ref: '#/definitions/JSONRPCErrorResponse'
+      - $ref: '#/definitions/DeleteTaskPushNotificationConfigSuccessResponse'
+    description: JSON-RPC response for the 'tasks/pushNotificationConfig/delete' method.
+  DeleteTaskPushNotificationConfigSuccessResponse:
+    description: JSON-RPC success response model for the 'tasks/pushNotificationConfig/delete' method.
+    properties:
+      id:
+        description: |-
+          An identifier established by the Client that MUST contain a String, Number.
+          Numbers SHOULD NOT contain fractional parts.
+        type:
+          - string
+          - integer
+          - 'null'
+      jsonrpc:
+        const: '2.0'
+        description: Specifies the version of the JSON-RPC protocol. MUST be exactly "2.0".
+        type: string
+      result:
+        description: The result object on success.
+        type: 'null'
+    required:
+      - id
+      - jsonrpc
+      - result
+    type: object
   FileBase:
     description: Represents the base entity for FileParts
     properties:
@@ -460,6 +561,20 @@ definitions:
     required:
       - uri
     type: object
+  GetTaskPushNotificationConfigParams:
+    description: Parameters for fetching a pushNotificationConfiguration associated with a Task
+    properties:
+      id:
+        description: Task id.
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      pushNotificationConfigId:
+        type: string
+    required:
+      - id
+    type: object
   GetTaskPushNotificationConfigRequest:
     description: JSON-RPC request model for the 'tasks/pushNotificationConfig/get' method.
     properties:
@@ -479,8 +594,12 @@ definitions:
         description: A String containing the name of the method to be invoked.
         type: string
       params:
-        $ref: '#/definitions/TaskIdParams'
-        description: A Structured value that holds the parameter values to be used during the invocation of the method.
+        anyOf:
+          - $ref: '#/definitions/TaskIdParams'
+          - $ref: '#/definitions/GetTaskPushNotificationConfigParams'
+        description: |-
+          A Structured value that holds the parameter values to be used during the invocation of the method.
+          TaskIdParams type is deprecated for this method
     required:
       - id
       - jsonrpc
@@ -838,6 +957,75 @@ definitions:
         type: string
       result:
         description: The result object on success
+    required:
+      - id
+      - jsonrpc
+      - result
+    type: object
+  ListTaskPushNotificationConfigParams:
+    description: Parameters for getting list of pushNotificationConfigurations associated with a Task
+    properties:
+      id:
+        description: Task id.
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+    required:
+      - id
+    type: object
+  ListTaskPushNotificationConfigRequest:
+    description: JSON-RPC request model for the 'tasks/pushNotificationConfig/list' method.
+    properties:
+      id:
+        description: |-
+          An identifier established by the Client that MUST contain a String, Number.
+          Numbers SHOULD NOT contain fractional parts.
+        type:
+          - string
+          - integer
+      jsonrpc:
+        const: '2.0'
+        description: Specifies the version of the JSON-RPC protocol. MUST be exactly "2.0".
+        type: string
+      method:
+        const: tasks/pushNotificationConfig/list
+        description: A String containing the name of the method to be invoked.
+        type: string
+      params:
+        $ref: '#/definitions/ListTaskPushNotificationConfigParams'
+        description: A Structured value that holds the parameter values to be used during the invocation of the method.
+    required:
+      - id
+      - jsonrpc
+      - method
+      - params
+    type: object
+  ListTaskPushNotificationConfigResponse:
+    anyOf:
+      - $ref: '#/definitions/JSONRPCErrorResponse'
+      - $ref: '#/definitions/ListTaskPushNotificationConfigSuccessResponse'
+    description: JSON-RPC response for the 'tasks/pushNotificationConfig/list' method.
+  ListTaskPushNotificationConfigSuccessResponse:
+    description: JSON-RPC success response model for the 'tasks/pushNotificationConfig/list' method.
+    properties:
+      id:
+        description: |-
+          An identifier established by the Client that MUST contain a String, Number.
+          Numbers SHOULD NOT contain fractional parts.
+        type:
+          - string
+          - integer
+          - 'null'
+      jsonrpc:
+        const: '2.0'
+        description: Specifies the version of the JSON-RPC protocol. MUST be exactly "2.0".
+        type: string
+      result:
+        description: The result object on success.
+        items:
+          $ref: '#/definitions/TaskPushNotificationConfig'
+        type: array
     required:
       - id
       - jsonrpc


### PR DESCRIPTION
## Summary

This PR implements actual push notification delivery when task states change in the A2A server. Previously, push notification configurations were managed but no notifications were sent. The implementation adds a new PushNotificationSender interface with HTTP webhook support, integrates it into the DefaultTaskManager, and automatically sends notifications on task state changes. Notifications are delivered asynchronously via HTTP POST to configured webhook URLs with proper authentication (Bearer/Basic).
