### PR TITLE
feat: Implement GetHealth method for A2A client

### DIFF
--- a/adk/client/client.go
+++ b/adk/client/client.go
@@ -40,13 +40,6 @@ type A2AClient interface {
 
 var _ A2AClient = (*Client)(nil)
 
-// Health status constants
-const (
-	HealthStatusHealthy   = "healthy"
-	HealthStatusDegraded  = "degraded"
-	HealthStatusUnhealthy = "unhealthy"
-)
-
 // HealthResponse represents the response from the health endpoint
 type HealthResponse struct {
 	Status string `json:"status"`
@@ -457,14 +450,12 @@ func (c *Client) GetHealth(ctx context.Context) (*HealthResponse, error) {
 		return nil, fmt.Errorf("failed to decode health response: %w", err)
 	}
 
-	// Validate response body
 	if healthResp.Status == "" {
 		c.logger.Error("health response missing status field")
 		return nil, fmt.Errorf("health response missing status field")
 	}
 
-	// Validate status value
-	validStatuses := []string{HealthStatusHealthy, HealthStatusDegraded, HealthStatusUnhealthy}
+	validStatuses := []string{adk.HealthStatusHealthy, adk.HealthStatusDegraded, adk.HealthStatusUnhealthy}
 	isValidStatus := false
 	for _, validStatus := range validStatuses {
 		if healthResp.Status == validStatus {
@@ -474,7 +465,6 @@ func (c *Client) GetHealth(ctx context.Context) (*HealthResponse, error) {
 	}
 	if !isValidStatus {
 		c.logger.Warn("health response contains unknown status", zap.String("status", healthResp.Status))
-		// Don't return error for unknown statuses to maintain backward compatibility
 	}
 
 	c.logger.Debug("health check completed successfully", zap.String("status", healthResp.Status))

--- a/adk/client/client_test.go
+++ b/adk/client/client_test.go
@@ -2131,18 +2131,18 @@ func TestClient_GetHealth_WithConstants(t *testing.T) {
 	}{
 		{
 			name:     "healthy status constant",
-			status:   client.HealthStatusHealthy,
-			expected: client.HealthStatusHealthy,
+			status:   adk.HealthStatusHealthy,
+			expected: adk.HealthStatusHealthy,
 		},
 		{
 			name:     "degraded status constant",
-			status:   client.HealthStatusDegraded,
-			expected: client.HealthStatusDegraded,
+			status:   adk.HealthStatusDegraded,
+			expected: adk.HealthStatusDegraded,
 		},
 		{
 			name:     "unhealthy status constant",
-			status:   client.HealthStatusUnhealthy,
-			expected: client.HealthStatusUnhealthy,
+			status:   adk.HealthStatusUnhealthy,
+			expected: adk.HealthStatusUnhealthy,
 		},
 	}
 

--- a/adk/client/mocks/fake_a2a_client.go
+++ b/adk/client/mocks/fake_a2a_client.go
@@ -40,6 +40,19 @@ type FakeA2AClient struct {
 		result1 *adk.AgentCard
 		result2 error
 	}
+	GetHealthStub        func(context.Context) (*client.HealthResponse, error)
+	getHealthMutex       sync.RWMutex
+	getHealthArgsForCall []struct {
+		arg1 context.Context
+	}
+	getHealthReturns struct {
+		result1 *client.HealthResponse
+		result2 error
+	}
+	getHealthReturnsOnCall map[int]struct {
+		result1 *client.HealthResponse
+		result2 error
+	}
 	GetBaseURLStub        func() string
 	getBaseURLMutex       sync.RWMutex
 	getBaseURLArgsForCall []struct {
@@ -259,6 +272,70 @@ func (fake *FakeA2AClient) GetAgentCardReturnsOnCall(i int, result1 *adk.AgentCa
 	}
 	fake.getAgentCardReturnsOnCall[i] = struct {
 		result1 *adk.AgentCard
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeA2AClient) GetHealth(arg1 context.Context) (*client.HealthResponse, error) {
+	fake.getHealthMutex.Lock()
+	ret, specificReturn := fake.getHealthReturnsOnCall[len(fake.getHealthArgsForCall)]
+	fake.getHealthArgsForCall = append(fake.getHealthArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.GetHealthStub
+	fakeReturns := fake.getHealthReturns
+	fake.recordInvocation("GetHealth", []interface{}{arg1})
+	fake.getHealthMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeA2AClient) GetHealthCallCount() int {
+	fake.getHealthMutex.RLock()
+	defer fake.getHealthMutex.RUnlock()
+	return len(fake.getHealthArgsForCall)
+}
+
+func (fake *FakeA2AClient) GetHealthCalls(stub func(context.Context) (*client.HealthResponse, error)) {
+	fake.getHealthMutex.Lock()
+	defer fake.getHealthMutex.Unlock()
+	fake.GetHealthStub = stub
+}
+
+func (fake *FakeA2AClient) GetHealthArgsForCall(i int) context.Context {
+	fake.getHealthMutex.RLock()
+	defer fake.getHealthMutex.RUnlock()
+	argsForCall := fake.getHealthArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeA2AClient) GetHealthReturns(result1 *client.HealthResponse, result2 error) {
+	fake.getHealthMutex.Lock()
+	defer fake.getHealthMutex.Unlock()
+	fake.GetHealthStub = nil
+	fake.getHealthReturns = struct {
+		result1 *client.HealthResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeA2AClient) GetHealthReturnsOnCall(i int, result1 *client.HealthResponse, result2 error) {
+	fake.getHealthMutex.Lock()
+	defer fake.getHealthMutex.Unlock()
+	fake.GetHealthStub = nil
+	if fake.getHealthReturnsOnCall == nil {
+		fake.getHealthReturnsOnCall = make(map[int]struct {
+			result1 *client.HealthResponse
+			result2 error
+		})
+	}
+	fake.getHealthReturnsOnCall[i] = struct {
+		result1 *client.HealthResponse
 		result2 error
 	}{result1, result2}
 }
@@ -730,6 +807,8 @@ func (fake *FakeA2AClient) Invocations() map[string][][]interface{} {
 	defer fake.cancelTaskMutex.RUnlock()
 	fake.getAgentCardMutex.RLock()
 	defer fake.getAgentCardMutex.RUnlock()
+	fake.getHealthMutex.RLock()
+	defer fake.getHealthMutex.RUnlock()
 	fake.getBaseURLMutex.RLock()
 	defer fake.getBaseURLMutex.RUnlock()
 	fake.getLoggerMutex.RLock()

--- a/adk/client/mocks/fake_a2a_client.go
+++ b/adk/client/mocks/fake_a2a_client.go
@@ -40,6 +40,16 @@ type FakeA2AClient struct {
 		result1 *adk.AgentCard
 		result2 error
 	}
+	GetBaseURLStub        func() string
+	getBaseURLMutex       sync.RWMutex
+	getBaseURLArgsForCall []struct {
+	}
+	getBaseURLReturns struct {
+		result1 string
+	}
+	getBaseURLReturnsOnCall map[int]struct {
+		result1 string
+	}
 	GetHealthStub        func(context.Context) (*client.HealthResponse, error)
 	getHealthMutex       sync.RWMutex
 	getHealthArgsForCall []struct {
@@ -52,16 +62,6 @@ type FakeA2AClient struct {
 	getHealthReturnsOnCall map[int]struct {
 		result1 *client.HealthResponse
 		result2 error
-	}
-	GetBaseURLStub        func() string
-	getBaseURLMutex       sync.RWMutex
-	getBaseURLArgsForCall []struct {
-	}
-	getBaseURLReturns struct {
-		result1 string
-	}
-	getBaseURLReturnsOnCall map[int]struct {
-		result1 string
 	}
 	GetLoggerStub        func() *zap.Logger
 	getLoggerMutex       sync.RWMutex
@@ -276,6 +276,59 @@ func (fake *FakeA2AClient) GetAgentCardReturnsOnCall(i int, result1 *adk.AgentCa
 	}{result1, result2}
 }
 
+func (fake *FakeA2AClient) GetBaseURL() string {
+	fake.getBaseURLMutex.Lock()
+	ret, specificReturn := fake.getBaseURLReturnsOnCall[len(fake.getBaseURLArgsForCall)]
+	fake.getBaseURLArgsForCall = append(fake.getBaseURLArgsForCall, struct {
+	}{})
+	stub := fake.GetBaseURLStub
+	fakeReturns := fake.getBaseURLReturns
+	fake.recordInvocation("GetBaseURL", []interface{}{})
+	fake.getBaseURLMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeA2AClient) GetBaseURLCallCount() int {
+	fake.getBaseURLMutex.RLock()
+	defer fake.getBaseURLMutex.RUnlock()
+	return len(fake.getBaseURLArgsForCall)
+}
+
+func (fake *FakeA2AClient) GetBaseURLCalls(stub func() string) {
+	fake.getBaseURLMutex.Lock()
+	defer fake.getBaseURLMutex.Unlock()
+	fake.GetBaseURLStub = stub
+}
+
+func (fake *FakeA2AClient) GetBaseURLReturns(result1 string) {
+	fake.getBaseURLMutex.Lock()
+	defer fake.getBaseURLMutex.Unlock()
+	fake.GetBaseURLStub = nil
+	fake.getBaseURLReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeA2AClient) GetBaseURLReturnsOnCall(i int, result1 string) {
+	fake.getBaseURLMutex.Lock()
+	defer fake.getBaseURLMutex.Unlock()
+	fake.GetBaseURLStub = nil
+	if fake.getBaseURLReturnsOnCall == nil {
+		fake.getBaseURLReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.getBaseURLReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeA2AClient) GetHealth(arg1 context.Context) (*client.HealthResponse, error) {
 	fake.getHealthMutex.Lock()
 	ret, specificReturn := fake.getHealthReturnsOnCall[len(fake.getHealthArgsForCall)]
@@ -338,59 +391,6 @@ func (fake *FakeA2AClient) GetHealthReturnsOnCall(i int, result1 *client.HealthR
 		result1 *client.HealthResponse
 		result2 error
 	}{result1, result2}
-}
-
-func (fake *FakeA2AClient) GetBaseURL() string {
-	fake.getBaseURLMutex.Lock()
-	ret, specificReturn := fake.getBaseURLReturnsOnCall[len(fake.getBaseURLArgsForCall)]
-	fake.getBaseURLArgsForCall = append(fake.getBaseURLArgsForCall, struct {
-	}{})
-	stub := fake.GetBaseURLStub
-	fakeReturns := fake.getBaseURLReturns
-	fake.recordInvocation("GetBaseURL", []interface{}{})
-	fake.getBaseURLMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeA2AClient) GetBaseURLCallCount() int {
-	fake.getBaseURLMutex.RLock()
-	defer fake.getBaseURLMutex.RUnlock()
-	return len(fake.getBaseURLArgsForCall)
-}
-
-func (fake *FakeA2AClient) GetBaseURLCalls(stub func() string) {
-	fake.getBaseURLMutex.Lock()
-	defer fake.getBaseURLMutex.Unlock()
-	fake.GetBaseURLStub = stub
-}
-
-func (fake *FakeA2AClient) GetBaseURLReturns(result1 string) {
-	fake.getBaseURLMutex.Lock()
-	defer fake.getBaseURLMutex.Unlock()
-	fake.GetBaseURLStub = nil
-	fake.getBaseURLReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeA2AClient) GetBaseURLReturnsOnCall(i int, result1 string) {
-	fake.getBaseURLMutex.Lock()
-	defer fake.getBaseURLMutex.Unlock()
-	fake.GetBaseURLStub = nil
-	if fake.getBaseURLReturnsOnCall == nil {
-		fake.getBaseURLReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.getBaseURLReturnsOnCall[i] = struct {
-		result1 string
-	}{result1}
 }
 
 func (fake *FakeA2AClient) GetLogger() *zap.Logger {
@@ -807,10 +807,10 @@ func (fake *FakeA2AClient) Invocations() map[string][][]interface{} {
 	defer fake.cancelTaskMutex.RUnlock()
 	fake.getAgentCardMutex.RLock()
 	defer fake.getAgentCardMutex.RUnlock()
-	fake.getHealthMutex.RLock()
-	defer fake.getHealthMutex.RUnlock()
 	fake.getBaseURLMutex.RLock()
 	defer fake.getBaseURLMutex.RUnlock()
+	fake.getHealthMutex.RLock()
+	defer fake.getHealthMutex.RUnlock()
 	fake.getLoggerMutex.RLock()
 	defer fake.getLoggerMutex.RUnlock()
 	fake.getTaskMutex.RLock()

--- a/adk/server/server.go
+++ b/adk/server/server.go
@@ -11,6 +11,7 @@ import (
 	gin "github.com/gin-gonic/gin"
 	uuid "github.com/google/uuid"
 	adk "github.com/inference-gateway/a2a/adk"
+	client "github.com/inference-gateway/a2a/adk/client"
 	config "github.com/inference-gateway/a2a/adk/server/config"
 	middlewares "github.com/inference-gateway/a2a/adk/server/middlewares"
 	otel "github.com/inference-gateway/a2a/adk/server/otel"
@@ -262,7 +263,7 @@ func (s *A2AServerImpl) setupRouter(cfg *config.Config) *gin.Engine {
 	r := gin.Default()
 
 	r.GET("/health", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"status": "healthy"})
+		c.JSON(http.StatusOK, gin.H{"status": client.HealthStatusHealthy})
 	})
 
 	r.GET("/.well-known/agent.json", s.handleAgentInfo)

--- a/adk/server/server.go
+++ b/adk/server/server.go
@@ -11,7 +11,6 @@ import (
 	gin "github.com/gin-gonic/gin"
 	uuid "github.com/google/uuid"
 	adk "github.com/inference-gateway/a2a/adk"
-	client "github.com/inference-gateway/a2a/adk/client"
 	config "github.com/inference-gateway/a2a/adk/server/config"
 	middlewares "github.com/inference-gateway/a2a/adk/server/middlewares"
 	otel "github.com/inference-gateway/a2a/adk/server/otel"
@@ -263,7 +262,7 @@ func (s *A2AServerImpl) setupRouter(cfg *config.Config) *gin.Engine {
 	r := gin.Default()
 
 	r.GET("/health", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"status": client.HealthStatusHealthy})
+		c.JSON(http.StatusOK, gin.H{"status": adk.HealthStatusHealthy})
 	})
 
 	r.GET("/.well-known/agent.json", s.handleAgentInfo)

--- a/adk/types.go
+++ b/adk/types.go
@@ -47,3 +47,10 @@ type FileData struct {
 	Bytes    *string `json:"bytes,omitempty"`
 	URI      *string `json:"uri,omitempty"`
 }
+
+// Health status constants
+const (
+	HealthStatusHealthy   = "healthy"
+	HealthStatusDegraded  = "degraded"
+	HealthStatusUnhealthy = "unhealthy"
+)


### PR DESCRIPTION
Implement GetHealth method for A2A client to check agent health status

## Changes
- Add GetHealth method to A2AClient interface
- Implement health check via GET /health endpoint
- Return HealthResponse struct with Status field
- Follow same pattern as GetAgentCard implementation
- Add comprehensive tests for success, error, and edge cases
- Support context cancellation and custom user agents

## Files Modified
- `adk/client/client.go` - Added GetHealth method and HealthResponse type
- `adk/client/client_test.go` - Added comprehensive test suite

## Usage Example
```go
client = client.NewClient("http://localhost:8080")
health, err := client.GetHealth(context.Background())
if err != nil {
    log.Fatal(err)
}
fmt.Printf("Agent status: %s\n", health.Status)
```

Fixes #9

Generated with [Claude Code](https://claude.ai/code)