### PR TITLE
fix: Update sdk dependency to v1.9.0 and add middleware options for chat completion methods

### DIFF
--- a/adk/server/agent_llm_client.go
+++ b/adk/server/agent_llm_client.go
@@ -109,7 +109,10 @@ func (c *OpenAICompatibleLLMClient) CreateChatCompletion(ctx context.Context, me
 		}
 
 		if len(tools) > 0 {
-			response, lastErr = c.client.WithOptions(options).WithTools(&tools).GenerateContent(
+			response, lastErr = c.client.WithMiddlewareOptions(&sdk.MiddlewareOptions{
+				SkipA2A: true,
+				SkipMCP: true,
+			}).WithOptions(options).WithTools(&tools).GenerateContent(
 				ctx,
 				c.provider,
 				c.model,
@@ -167,14 +170,20 @@ func (c *OpenAICompatibleLLMClient) CreateStreamingChatCompletion(ctx context.Co
 		var err error
 
 		if len(tools) > 0 {
-			events, err = c.client.WithOptions(options).WithTools(&tools).GenerateContentStream(
+			events, err = c.client.WithMiddlewareOptions(&sdk.MiddlewareOptions{
+				SkipA2A: true,
+				SkipMCP: true,
+			}).WithOptions(options).WithTools(&tools).GenerateContentStream(
 				ctx,
 				c.provider,
 				c.model,
 				messages,
 			)
 		} else {
-			events, err = c.client.WithOptions(options).GenerateContentStream(
+			events, err = c.client.WithMiddlewareOptions(&sdk.MiddlewareOptions{
+				SkipA2A: true,
+				SkipMCP: true,
+			}).WithOptions(options).GenerateContentStream(
 				ctx,
 				c.provider,
 				c.model,

--- a/examples/server/go.mod
+++ b/examples/server/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/go-resty/resty/v2 v2.16.3 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/inference-gateway/sdk v1.8.1 // indirect
+	github.com/inference-gateway/sdk v1.9.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/examples/server/go.sum
+++ b/examples/server/go.sum
@@ -46,8 +46,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/inference-gateway/sdk v1.8.1 h1:mSyXooS2xPOwXr7k+U6GS3NwKxZBIyMQSe6GoBQNHZ0=
-github.com/inference-gateway/sdk v1.8.1/go.mod h1:3TTD7Kbr7FRt+9ZbCPAm3u0tXUIWx7flZuwrRgZgrdk=
+github.com/inference-gateway/sdk v1.9.0 h1:glkwm8KoMckmEVt0KSzgvd+5kO4WWfwyRI1PgoJpdrY=
+github.com/inference-gateway/sdk v1.9.0/go.mod h1:3TTD7Kbr7FRt+9ZbCPAm3u0tXUIWx7flZuwrRgZgrdk=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/gin-gonic/gin v1.10.1
 	github.com/google/uuid v1.6.0
-	github.com/inference-gateway/sdk v1.8.1
+	github.com/inference-gateway/sdk v1.9.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/inference-gateway/sdk v1.8.1 h1:mSyXooS2xPOwXr7k+U6GS3NwKxZBIyMQSe6GoBQNHZ0=
-github.com/inference-gateway/sdk v1.8.1/go.mod h1:3TTD7Kbr7FRt+9ZbCPAm3u0tXUIWx7flZuwrRgZgrdk=
+github.com/inference-gateway/sdk v1.9.0 h1:glkwm8KoMckmEVt0KSzgvd+5kO4WWfwyRI1PgoJpdrY=
+github.com/inference-gateway/sdk v1.9.0/go.mod h1:3TTD7Kbr7FRt+9ZbCPAm3u0tXUIWx7flZuwrRgZgrdk=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=


### PR DESCRIPTION
When using the internal OpenAI compatible AI inside of the A2A agent server and using the inference gateway you typically would like to skip the middlewares to avoid recursion.

This Pull Requests adds the headers X-MCP-Bypass and X-A2A-Bypass to the request to avoid using the middleware and using the provider directly.
