### PR TITLE
feat(config): Remove environment variable configurability for agent metadata

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -29,8 +29,20 @@ tasks:
 
   build:
     desc: 'Build the Go application'
+    vars:
+      AGENT_NAME: '{{.AGENT_NAME | default "helloworld-agent"}}'
+      AGENT_VERSION: '{{.AGENT_VERSION | default "1.0.0"}}'
     cmds:
-      - go build -o bin/app .
+      - go build -ldflags="-X github.com/inference-gateway/a2a/adk/server.BuildAgentName={{.AGENT_NAME}} -X github.com/inference-gateway/a2a/adk/server.BuildAgentVersion={{.AGENT_VERSION}}" -o bin/app .
+
+  build:with-metadata:
+    desc: 'Build the Go application with custom metadata'
+    vars:
+      AGENT_NAME: '{{.AGENT_NAME | default "helloworld-agent"}}'
+      AGENT_DESCRIPTION: '{{.AGENT_DESCRIPTION | default "A_simple_greeting_agent"}}'
+      AGENT_VERSION: '{{.AGENT_VERSION | default "1.0.0"}}'
+    cmds:
+      - go build -ldflags="-X github.com/inference-gateway/a2a/adk/server.BuildAgentName={{.AGENT_NAME}} -X 'github.com/inference-gateway/a2a/adk/server.BuildAgentDescription={{.AGENT_DESCRIPTION}}' -X github.com/inference-gateway/a2a/adk/server.BuildAgentVersion={{.AGENT_VERSION}}" -o bin/app .
 
   test:
     desc: 'Run tests'

--- a/adk/server/config/config.go
+++ b/adk/server/config/config.go
@@ -10,10 +10,10 @@ import (
 
 // Config holds all application configuration
 type Config struct {
-	AgentName                     string             `env:"AGENT_NAME,default=helloworld-agent"`
-	AgentDescription              string             `env:"AGENT_DESCRIPTION,default=A simple greeting agent that provides personalized greetings using the A2A protocol"`
+	AgentName                     string             // Build-time metadata, not configurable via environment
+	AgentDescription              string             // Build-time metadata, not configurable via environment
 	AgentURL                      string             `env:"AGENT_URL,default=http://helloworld-agent:8080"`
-	AgentVersion                  string             `env:"AGENT_VERSION,default=1.0.0"`
+	AgentVersion                  string             // Build-time metadata, not configurable via environment
 	Debug                         bool               `env:"DEBUG,default=false"`
 	Port                          string             `env:"PORT,default=8080"`
 	Timezone                      string             `env:"TIMEZONE,default=UTC" description:"Timezone for timestamps (e.g., UTC, America/New_York, Europe/London)"`

--- a/adk/server/server.go
+++ b/adk/server/server.go
@@ -19,6 +19,13 @@ import (
 	zap "go.uber.org/zap"
 )
 
+// Build-time metadata variables set via LD flags
+var (
+	BuildAgentName        = "helloworld-agent"
+	BuildAgentDescription = "A simple greeting agent that provides personalized greetings using the A2A protocol"
+	BuildAgentVersion     = "1.0.0"
+)
+
 // A2AServer defines the interface for an A2A-compatible server
 type A2AServer interface {
 	// Start starts the A2A server on the configured port
@@ -115,6 +122,17 @@ var _ A2AServer = (*A2AServerImpl)(nil)
 
 // NewA2AServer creates a new A2A server with the provided configuration and logger
 func NewA2AServer(cfg *config.Config, logger *zap.Logger, otel otel.OpenTelemetry) *A2AServerImpl {
+	// Set build-time metadata values if not already configured
+	if cfg.AgentName == "" {
+		cfg.AgentName = BuildAgentName
+	}
+	if cfg.AgentDescription == "" {
+		cfg.AgentDescription = BuildAgentDescription
+	}
+	if cfg.AgentVersion == "" {
+		cfg.AgentVersion = BuildAgentVersion
+	}
+
 	server := &A2AServerImpl{
 		cfg:       cfg,
 		logger:    logger,


### PR DESCRIPTION
Remove environment variables for AgentName, AgentDescription, and AgentVersion to make them compile-time constants instead of runtime configuration.

## Changes
- Add build-time metadata variables in server package
- Remove env tags from metadata fields in Config struct
- Update NewA2AServer to use build-time values as defaults
- Update Taskfile.yml build command to inject LD flags
- Maintain runtime setter methods for dynamic configuration when needed

Fixes #16

Generated with [Claude Code](https://claude.ai/code)