### PR TITLE
refactor(config): Move port config under SERVER_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ func main() {
         }
     }()
 
-    logger.Info("AI-powered A2A server running", zap.String("port", cfg.Port))
+    logger.Info("AI-powered A2A server running", zap.String("port", cfg.ServerConfig.Port))
 
     // Wait for shutdown signal
     select {}

--- a/adk/server/config/config.go
+++ b/adk/server/config/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	AgentURL                      string             `env:"AGENT_URL,default=http://helloworld-agent:8080"`
 	AgentVersion                  string             // Build-time metadata, not configurable via environment
 	Debug                         bool               `env:"DEBUG,default=false"`
-	Port                          string             `env:"PORT,default=8080"`
 	Timezone                      string             `env:"TIMEZONE,default=UTC" description:"Timezone for timestamps (e.g., UTC, America/New_York, Europe/London)"`
 	StreamingStatusUpdateInterval time.Duration      `env:"STREAMING_STATUS_UPDATE_INTERVAL,default=1s"`
 	AgentConfig                   AgentConfig        `env:",prefix=AGENT_CLIENT_"`
@@ -87,6 +86,7 @@ type QueueConfig struct {
 
 // ServerConfig holds HTTP server configuration
 type ServerConfig struct {
+	Port                  string        `env:"PORT,default=8080" description:"HTTP server port"`
 	ReadTimeout           time.Duration `env:"READ_TIMEOUT,default=120s" description:"HTTP server read timeout"`
 	WriteTimeout          time.Duration `env:"WRITE_TIMEOUT,default=120s" description:"HTTP server write timeout"`
 	IdleTimeout           time.Duration `env:"IDLE_TIMEOUT,default=120s" description:"HTTP server idle timeout"`

--- a/adk/server/config/config_test.go
+++ b/adk/server/config/config_test.go
@@ -26,7 +26,7 @@ func TestConfig_LoadWithLookuper(t *testing.T) {
 				assert.Equal(t, "http://helloworld-agent:8080", cfg.AgentURL)
 				assert.Equal(t, "", cfg.AgentVersion)
 				assert.False(t, cfg.Debug)
-				assert.Equal(t, "8080", cfg.Port)
+				assert.Equal(t, "8080", cfg.ServerConfig.Port)
 				assert.Equal(t, 1*time.Second, cfg.StreamingStatusUpdateInterval)
 
 				require.NotNil(t, cfg.AgentConfig)
@@ -55,6 +55,7 @@ func TestConfig_LoadWithLookuper(t *testing.T) {
 				assert.Equal(t, 30*time.Second, cfg.QueueConfig.CleanupInterval)
 
 				require.NotNil(t, cfg.ServerConfig)
+				assert.Equal(t, "8080", cfg.ServerConfig.Port)
 				assert.Equal(t, 120*time.Second, cfg.ServerConfig.ReadTimeout)
 				assert.Equal(t, 120*time.Second, cfg.ServerConfig.WriteTimeout)
 				assert.Equal(t, 120*time.Second, cfg.ServerConfig.IdleTimeout)
@@ -65,7 +66,7 @@ func TestConfig_LoadWithLookuper(t *testing.T) {
 			envVars: map[string]string{
 				"AGENT_URL":                        "http://localhost:9090",
 				"DEBUG":                            "true",
-				"PORT":                             "9090",
+				"SERVER_PORT":                      "9090",
 				"STREAMING_STATUS_UPDATE_INTERVAL": "5s",
 				"AGENT_CLIENT_PROVIDER":            "openai",
 				"AGENT_CLIENT_MODEL":               "gpt-4",
@@ -100,7 +101,7 @@ func TestConfig_LoadWithLookuper(t *testing.T) {
 				assert.Equal(t, "http://localhost:9090", cfg.AgentURL)
 				assert.Equal(t, "", cfg.AgentVersion)
 				assert.True(t, cfg.Debug)
-				assert.Equal(t, "9090", cfg.Port)
+				assert.Equal(t, "9090", cfg.ServerConfig.Port)
 				assert.Equal(t, 5*time.Second, cfg.StreamingStatusUpdateInterval)
 
 				// Test LLM config overrides
@@ -143,6 +144,7 @@ func TestConfig_LoadWithLookuper(t *testing.T) {
 
 				// Test Server config overrides
 				require.NotNil(t, cfg.ServerConfig)
+				assert.Equal(t, "9090", cfg.ServerConfig.Port)
 				assert.Equal(t, 180*time.Second, cfg.ServerConfig.ReadTimeout)
 				assert.Equal(t, 180*time.Second, cfg.ServerConfig.WriteTimeout)
 				assert.Equal(t, 300*time.Second, cfg.ServerConfig.IdleTimeout)
@@ -162,7 +164,7 @@ func TestConfig_LoadWithLookuper(t *testing.T) {
 
 				assert.Equal(t, "", cfg.AgentDescription)
 				assert.Equal(t, "", cfg.AgentVersion)
-				assert.Equal(t, "8080", cfg.Port)
+				assert.Equal(t, "8080", cfg.ServerConfig.Port)
 
 				require.NotNil(t, cfg.AgentConfig)
 				assert.Equal(t, "anthropic", cfg.AgentConfig.Provider)

--- a/adk/server/server.go
+++ b/adk/server/server.go
@@ -320,14 +320,14 @@ func (s *A2AServerImpl) Start(ctx context.Context) error {
 	router := s.setupRouter(s.cfg)
 
 	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf(":%s", s.cfg.Port),
+		Addr:         fmt.Sprintf(":%s", s.cfg.ServerConfig.Port),
 		Handler:      router,
 		ReadTimeout:  s.cfg.ServerConfig.ReadTimeout,
 		WriteTimeout: s.cfg.ServerConfig.WriteTimeout,
 		IdleTimeout:  s.cfg.ServerConfig.IdleTimeout,
 	}
 
-	s.logger.Info("starting A2A server", zap.String("port", s.cfg.Port))
+	s.logger.Info("starting A2A server", zap.String("port", s.cfg.ServerConfig.Port))
 
 	if s.cfg.TelemetryConfig.Enable && s.otel != nil {
 		go func() {

--- a/adk/server/server_builder_test.go
+++ b/adk/server/server_builder_test.go
@@ -24,7 +24,7 @@ func TestA2AServerBuilder_BasicConstruction(t *testing.T) {
 				return config.Config{
 					AgentName:        "test-agent",
 					AgentDescription: "Test agent description",
-					Port:             "8080",
+					ServerConfig:     config.ServerConfig{Port: "8080"},
 				}
 			},
 			expectPanic: false,
@@ -59,8 +59,8 @@ func TestA2AServerBuilder_BasicConstruction(t *testing.T) {
 
 func TestA2AServerBuilder_WithTaskHandler(t *testing.T) {
 	cfg := config.Config{
-		AgentName: "test-agent",
-		Port:      "8080",
+		AgentName:    "test-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
 	}
 	logger := zap.NewNop()
 	mockTaskHandler := &mocks.FakeTaskHandler{}
@@ -75,8 +75,8 @@ func TestA2AServerBuilder_WithTaskHandler(t *testing.T) {
 
 func TestA2AServerBuilder_WithTaskResultProcessor(t *testing.T) {
 	cfg := config.Config{
-		AgentName: "test-agent",
-		Port:      "8080",
+		AgentName:    "test-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
 	}
 	logger := zap.NewNop()
 	mockProcessor := &mocks.FakeTaskResultProcessor{}
@@ -90,8 +90,8 @@ func TestA2AServerBuilder_WithTaskResultProcessor(t *testing.T) {
 
 func TestA2AServerBuilder_WithAgent(t *testing.T) {
 	cfg := config.Config{
-		AgentName: "test-agent",
-		Port:      "8080",
+		AgentName:    "test-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
 	}
 	logger := zap.NewNop()
 	systemPrompt := "You are a helpful assistant"
@@ -111,8 +111,8 @@ func TestA2AServerBuilder_WithAgent(t *testing.T) {
 
 func TestA2AServerBuilder_WithAgentAndConfig(t *testing.T) {
 	cfg := config.Config{
-		AgentName: "test-agent",
-		Port:      "8080",
+		AgentName:    "test-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
 	}
 	logger := zap.NewNop()
 	agentConfig := &config.AgentConfig{
@@ -135,8 +135,8 @@ func TestA2AServerBuilder_WithAgentAndConfig(t *testing.T) {
 
 func TestA2AServerBuilder_ChainedCalls(t *testing.T) {
 	cfg := config.Config{
-		AgentName: "test-agent",
-		Port:      "8080",
+		AgentName:    "test-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
 	}
 	logger := zap.NewNop()
 	mockTaskHandler := &mocks.FakeTaskHandler{}
@@ -165,8 +165,8 @@ func TestNewDefaultA2AServer(t *testing.T) {
 
 func TestCustomA2AServer(t *testing.T) {
 	cfg := config.Config{
-		AgentName: "custom-agent",
-		Port:      "8080",
+		AgentName:    "custom-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
 	}
 	logger := zap.NewNop()
 	mockTaskHandler := &mocks.FakeTaskHandler{}
@@ -211,8 +211,8 @@ func TestA2AServerBuilderInterface_WithMocks(t *testing.T) {
 
 func TestA2AServerBuilderInterface_Polymorphism(t *testing.T) {
 	cfg := config.Config{
-		AgentName: "test-agent",
-		Port:      "8080",
+		AgentName:    "test-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
 	}
 	logger := zap.NewNop()
 
@@ -262,9 +262,9 @@ func TestServerBuilderAppliesAgentConfigDefaults(t *testing.T) {
 	logger := zap.NewNop()
 
 	cfg := config.Config{
-		AgentName: "test-agent",
-		Port:      "8080",
-		Debug:     true,
+		AgentName:    "test-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
+		Debug:        true,
 		QueueConfig: config.QueueConfig{
 			CleanupInterval: 5 * time.Minute,
 		},
@@ -287,9 +287,9 @@ func TestServerBuilderPreservesExplicitAgentConfig(t *testing.T) {
 	logger := zap.NewNop()
 
 	cfg := config.Config{
-		AgentName: "test-agent",
-		Port:      "8080",
-		Debug:     true,
+		AgentName:    "test-agent",
+		ServerConfig: config.ServerConfig{Port: "8080"},
+		Debug:        true,
 		AgentConfig: config.AgentConfig{
 			MaxConversationHistory:      5,
 			SystemPrompt:                "Custom system prompt",

--- a/adk/server/server_test.go
+++ b/adk/server/server_test.go
@@ -273,7 +273,7 @@ func TestDefaultA2AServer_SetDependencies(t *testing.T) {
 		AgentDescription: "A custom test agent for dependency injection",
 		AgentURL:         "http://custom-agent:9090",
 		AgentVersion:     "2.5.0",
-		Port:             "9090",
+		ServerConfig:     config.ServerConfig{Port: "9090"},
 		Debug:            true,
 	}
 
@@ -298,7 +298,7 @@ func TestA2AServerBuilder_UsesProvidedConfiguration(t *testing.T) {
 		AgentDescription: "A test agent with custom configuration",
 		AgentURL:         "http://test-agent:9999",
 		AgentVersion:     "2.0.0",
-		Port:             "9999",
+		ServerConfig:     config.ServerConfig{Port: "9999"},
 		Debug:            true,
 	}
 
@@ -328,7 +328,7 @@ func TestA2AServerBuilder_UsesProvidedCapabilitiesConfiguration(t *testing.T) {
 		AgentDescription: "A test agent",
 		AgentURL:         "http://test-agent:8080",
 		AgentVersion:     "1.0.0",
-		Port:             "8080",
+		ServerConfig:     config.ServerConfig{Port: "8080"},
 		CapabilitiesConfig: config.CapabilitiesConfig{
 			Streaming:              false,
 			PushNotifications:      false,
@@ -359,7 +359,7 @@ func TestA2AServerBuilder_HandlesNilConfigurationSafely(t *testing.T) {
 		AgentDescription: "A test agent",
 		AgentURL:         "http://test-agent:8080",
 		AgentVersion:     "1.0.0",
-		Port:             "8080",
+		ServerConfig:     config.ServerConfig{Port: "8080"},
 	}
 
 	logger := zap.NewNop()
@@ -410,7 +410,7 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 		AgentDescription: "A test agent",
 		AgentURL:         "http://test-agent:8080",
 		AgentVersion:     "1.0.0",
-		Port:             "8080",
+		ServerConfig:     config.ServerConfig{Port: "8080"},
 		Debug:            false,
 		QueueConfig: config.QueueConfig{
 			MaxSize:         10,
@@ -495,7 +495,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 		AgentDescription: "A weather agent",
 		AgentURL:         "http://weather-agent:8080",
 		AgentVersion:     "1.0.0",
-		Port:             "8080",
+		ServerConfig:     config.ServerConfig{Port: "8080"},
 		Debug:            false,
 		QueueConfig: config.QueueConfig{
 			MaxSize:         10,

--- a/examples/server/cmd/aipowered/main.go
+++ b/examples/server/cmd/aipowered/main.go
@@ -171,7 +171,7 @@ func main() {
 		}
 	}()
 
-	logger.Info("🌐 server running", zap.String("port", cfg.Port))
+	logger.Info("🌐 server running", zap.String("port", cfg.ServerConfig.Port))
 	fmt.Printf("\n🎯 Test with curl:\n")
 	fmt.Printf(`curl -X POST http://localhost:%s/a2a \
   -H "Content-Type: application/json" \
@@ -192,7 +192,7 @@ func main() {
       }
     },
     "id": 1
-  }'`, cfg.Port)
+  }'`, cfg.ServerConfig.Port)
 	fmt.Println()
 
 	// Wait for shutdown


### PR DESCRIPTION
Move Port field from root Config struct to ServerConfig for better organization since port is server-related configuration.

Changes:
- Move Port field from Config to ServerConfig struct
- Environment variable: PORT → SERVER_PORT
- Update all code references from cfg.Port to cfg.ServerConfig.Port
- Update all test configurations to use ServerConfig.Port

Closes #19

Generated with [Claude Code](https://claude.ai/code)