### PR TITLE
refactor(config): Move TLS config under SERVER_* prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,9 +960,9 @@ AUTH_CLIENT_ID="inference-gateway-client"
 AUTH_CLIENT_SECRET="your-secret"
 
 # TLS (optional)
-TLS_ENABLE="false"
-TLS_CERT_PATH="/path/to/cert.pem"
-TLS_KEY_PATH="/path/to/key.pem"
+SERVER_TLS_ENABLE="false"
+SERVER_TLS_CERT_PATH="/path/to/cert.pem"
+SERVER_TLS_KEY_PATH="/path/to/key.pem"
 ```
 
 ## 🌐 A2A Ecosystem

--- a/adk/server/config/config.go
+++ b/adk/server/config/config.go
@@ -19,7 +19,6 @@ type Config struct {
 	StreamingStatusUpdateInterval time.Duration      `env:"STREAMING_STATUS_UPDATE_INTERVAL,default=1s"`
 	AgentConfig                   AgentConfig        `env:",prefix=AGENT_CLIENT_"`
 	CapabilitiesConfig            CapabilitiesConfig `env:",prefix=CAPABILITIES_"`
-	TLSConfig                     TLSConfig          `env:",prefix=TLS_"`
 	AuthConfig                    AuthConfig         `env:",prefix=AUTH_"`
 	QueueConfig                   QueueConfig        `env:",prefix=QUEUE_"`
 	ServerConfig                  ServerConfig       `env:",prefix=SERVER_"`
@@ -91,6 +90,7 @@ type ServerConfig struct {
 	WriteTimeout          time.Duration `env:"WRITE_TIMEOUT,default=120s" description:"HTTP server write timeout"`
 	IdleTimeout           time.Duration `env:"IDLE_TIMEOUT,default=120s" description:"HTTP server idle timeout"`
 	DisableHealthcheckLog bool          `env:"DISABLE_HEALTHCHECK_LOG,default=true" description:"Disable logging for health check requests"`
+	TLSConfig             TLSConfig     `env:",prefix=TLS_"`
 }
 
 // TelemetryConfig holds telemetry configuration

--- a/adk/server/config/config_test.go
+++ b/adk/server/config/config_test.go
@@ -82,9 +82,9 @@ func TestConfig_LoadWithLookuper(t *testing.T) {
 				"CAPABILITIES_STREAMING":                      "false",
 				"CAPABILITIES_PUSH_NOTIFICATIONS":             "false",
 				"CAPABILITIES_STATE_TRANSITION_HISTORY":       "true",
-				"TLS_ENABLE":                                  "true",
-				"TLS_CERT_PATH":                               "/custom/cert.pem",
-				"TLS_KEY_PATH":                                "/custom/key.pem",
+				"SERVER_TLS_ENABLE":                           "true",
+				"SERVER_TLS_CERT_PATH":                        "/custom/cert.pem",
+				"SERVER_TLS_KEY_PATH":                         "/custom/key.pem",
 				"AUTH_ENABLE":                                 "true",
 				"AUTH_ISSUER_URL":                             "http://custom-keycloak:8080/realms/custom",
 				"AUTH_CLIENT_ID":                              "custom-client",
@@ -125,10 +125,10 @@ func TestConfig_LoadWithLookuper(t *testing.T) {
 				assert.True(t, cfg.CapabilitiesConfig.StateTransitionHistory)
 
 				// Test TLS config overrides
-				require.NotNil(t, cfg.TLSConfig)
-				assert.True(t, cfg.TLSConfig.Enable)
-				assert.Equal(t, "/custom/cert.pem", cfg.TLSConfig.CertPath)
-				assert.Equal(t, "/custom/key.pem", cfg.TLSConfig.KeyPath)
+				require.NotNil(t, cfg.ServerConfig.TLSConfig)
+				assert.True(t, cfg.ServerConfig.TLSConfig.Enable)
+				assert.Equal(t, "/custom/cert.pem", cfg.ServerConfig.TLSConfig.CertPath)
+				assert.Equal(t, "/custom/key.pem", cfg.ServerConfig.TLSConfig.KeyPath)
 
 				// Test Auth config overrides
 				require.NotNil(t, cfg.AuthConfig)

--- a/adk/server/server.go
+++ b/adk/server/server.go
@@ -348,8 +348,8 @@ func (s *A2AServerImpl) Start(ctx context.Context) error {
 
 	go s.StartTaskProcessor(ctx)
 
-	if s.cfg.TLSConfig.Enable {
-		return s.httpServer.ListenAndServeTLS(s.cfg.TLSConfig.CertPath, s.cfg.TLSConfig.KeyPath)
+	if s.cfg.ServerConfig.TLSConfig.Enable {
+		return s.httpServer.ListenAndServeTLS(s.cfg.ServerConfig.TLSConfig.CertPath, s.cfg.ServerConfig.TLSConfig.KeyPath)
 	}
 
 	return s.httpServer.ListenAndServe()


### PR DESCRIPTION
Fixes #21

This PR moves the TLS configuration from the root level to the ServerConfig struct for better organization.

## Changes
- Moved `TLSConfig` field from root `Config` struct to `ServerConfig` struct
- Changed environment variables from `TLS_*` to `SERVER_TLS_*`
- Updated code references to use `cfg.ServerConfig.TLSConfig`
- Updated tests and documentation with new environment variable names

## Environment Variables Updated
- `TLS_ENABLE` → `SERVER_TLS_ENABLE`
- `TLS_CERT_PATH` → `SERVER_TLS_CERT_PATH`
- `TLS_KEY_PATH` → `SERVER_TLS_KEY_PATH`

Generated with [Claude Code](https://claude.ai/code)