### PR TITLE
fix: Improve validation logic for task handler configuration

### DIFF
--- a/server/server_builder.go
+++ b/server/server_builder.go
@@ -327,12 +327,16 @@ func (b *A2AServerBuilderImpl) validateTaskHandlerConfiguration() error {
 		streamingEnabled = *b.agentCard.Capabilities.Streaming
 	}
 
-	if b.pollingTaskHandler == nil {
-		return fmt.Errorf("background task handler must be configured - use WithBackgroundTaskHandler() for custom handler or WithDefaultBackgroundTaskHandler() for a ready-to-use default handler")
+	if b.pollingTaskHandler == nil && b.streamingTaskHandler == nil {
+		return fmt.Errorf("at least one task handler must be configured - use WithBackgroundTaskHandler() and/or WithStreamingTaskHandler(), or use WithDefaultTaskHandlers() for both")
 	}
 
 	if streamingEnabled && b.streamingTaskHandler == nil {
 		return fmt.Errorf("streaming task handler must be configured when streaming is enabled in agent capabilities - use WithStreamingTaskHandler() for custom handler or WithDefaultStreamingTaskHandler() for a ready-to-use default handler")
+	}
+
+	if !streamingEnabled && b.pollingTaskHandler == nil {
+		return fmt.Errorf("background task handler must be configured when streaming is not enabled - use WithBackgroundTaskHandler() for custom handler or WithDefaultBackgroundTaskHandler() for a ready-to-use default handler")
 	}
 
 	return nil

--- a/server/server_builder_test.go
+++ b/server/server_builder_test.go
@@ -428,7 +428,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 			Build()
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "background task handler must be configured")
+		assert.Contains(t, err.Error(), "at least one task handler must be configured")
 	})
 
 	t.Run("fails when streaming enabled but no streaming task handler configured", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Improves the task handler validation logic in `A2AServerBuilder` to provide more flexible configuration while maintaining proper validation based on agent capabilities.

## Problem

The previous validation logic was too strict - it always required a background task handler to be configured, even when streaming was enabled. This prevented valid configurations where only a streaming handler was needed.

## Solution

The validation now follows a three-step approach:

1. **Check if at least one handler exists**: First validates that either a polling or streaming task handler is configured
2. **Validate streaming requirements**: If streaming is enabled in agent capabilities, ensure a streaming handler is configured
3. **Validate background requirements**: If streaming is not enabled, ensure a background/polling handler is configured

## Changes

### `server/server_builder.go:322-342`
- First checks if both handlers are nil → returns general error message
- Then checks streaming-specific requirements
- Finally checks background-specific requirements
- Provides clear, actionable error messages for each case

### `server/server_builder_test.go:431`
- Updated test assertion to expect the new general error message when no handlers are configured

## Benefits

- ✅ Allows streaming-only configurations when appropriate
- ✅ Allows background-only configurations when streaming is disabled
- ✅ Provides clear, context-specific error messages
- ✅ Maintains backward compatibility with existing code

## Test Plan

All existing tests pass, including:
- `TestA2AServerBuilder_Build_RequiresTaskHandlers` - validates all error cases
- Tests for streaming-only and background-only configurations
- Tests for invalid configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)