### PR TITLE
ci: Add missing prettier dependency and formatting steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - name: Install prettier
+        run: npm install -g prettier
+
+      - name: Format Go files
+        run: find . -name '*.go' -exec gofmt -w {} \;
+
+      - name: Format markdown files
+        run: find . -name '*.md' -exec prettier -w {} \;
+
       - name: Tidy Go modules
         run: find . -name 'go.mod' -execdir go mod tidy \;
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,6 +49,14 @@ jobs:
         run: |
           curl -s https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin v3.45.4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 'lts/*'
+
+      - name: Install prettier
+        run: npm install -g prettier
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta


### PR DESCRIPTION
## Summary

- Install prettier in both CI and Claude Code workflows
- Add formatting steps for Go files (gofmt) and markdown files (prettier) in CI
- Ensures `task format` command works correctly in CI environment

## Fixes

Closes #103

## Test plan

- [ ] CI workflow runs successfully with prettier installed
- [ ] Formatting steps execute without errors
- [ ] Claude Code workflow can use prettier for markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)