### PR TITLE
refactor: Migrate to the latest A2A proto schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: go install go.uber.org/mock/mockgen@v0.6.0
 
       - name: Install generator tool
-        run: go install github.com/inference-gateway/tools/cmd/generator@v0.1.2
+        run: go install github.com/inference-gateway/tools/cmd/generator@v0.2.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.1.0

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,7 +1,7 @@
 {
   "config": {
     "MD013": {
-      "line_length": 80
+      "line_length": 140
     },
     "MD029": false
   }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
     generates:
       - types/generated_types.go
     cmds:
-      - go run github.com/inference-gateway/tools/cmd/generator@v0.1.2 -generator jsonrpc -package types schema.yaml types/generated_types.go
+      - go run github.com/inference-gateway/tools/cmd/generator@v0.2.0 -generator jsonrpc -package types schema.yaml types/generated_types.go
 
   tidy:
     desc: 'Tidy all Go modules'

--- a/client/artifact_helper.go
+++ b/client/artifact_helper.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/inference-gateway/adk/types"
+	types "github.com/inference-gateway/adk/types"
 )
 
 // ArtifactHelper provides utility functions for working with artifacts in client responses
@@ -115,17 +115,8 @@ func (ah *ArtifactHelper) ExtractTextFromArtifact(artifact *types.Artifact) []st
 	}
 
 	for _, part := range artifact.Parts {
-		switch p := part.(type) {
-		case types.TextPart:
-			if p.Kind == "text" {
-				texts = append(texts, p.Text)
-			}
-		case map[string]any:
-			if kind, ok := p["kind"].(string); ok && kind == "text" {
-				if text, exists := p["text"].(string); exists {
-					texts = append(texts, text)
-				}
-			}
+		if part.Text != nil {
+			texts = append(texts, *part.Text)
 		}
 	}
 
@@ -141,23 +132,12 @@ func (ah *ArtifactHelper) ExtractFileDataFromArtifact(artifact *types.Artifact) 
 	}
 
 	for _, part := range artifact.Parts {
-		switch p := part.(type) {
-		case types.FilePart:
-			if p.Kind == "file" {
-				fileData, err := ah.extractFileFromPart(p)
-				if err != nil {
-					return nil, fmt.Errorf("failed to extract file from part: %w", err)
-				}
-				files = append(files, fileData)
+		if part.File != nil {
+			fileData, err := ah.extractFileFromPart(*part.File)
+			if err != nil {
+				return nil, fmt.Errorf("failed to extract file from part: %w", err)
 			}
-		case map[string]any:
-			if kind, ok := p["kind"].(string); ok && kind == "file" {
-				fileData, err := ah.extractFileFromMap(p)
-				if err != nil {
-					return nil, fmt.Errorf("failed to extract file from map part: %w", err)
-				}
-				files = append(files, fileData)
-			}
+			files = append(files, fileData)
 		}
 	}
 
@@ -173,17 +153,8 @@ func (ah *ArtifactHelper) ExtractDataFromArtifact(artifact *types.Artifact) []ma
 	}
 
 	for _, part := range artifact.Parts {
-		switch p := part.(type) {
-		case types.DataPart:
-			if p.Kind == "data" {
-				dataList = append(dataList, p.Data)
-			}
-		case map[string]any:
-			if kind, ok := p["kind"].(string); ok && kind == "data" {
-				if data, exists := p["data"].(map[string]any); exists {
-					dataList = append(dataList, data)
-				}
-			}
+		if part.Data != nil {
+			dataList = append(dataList, part.Data.Data)
 		}
 	}
 
@@ -226,69 +197,27 @@ func (fd *FileData) GetMIMEType() string {
 
 // isPartOfKind checks if a part is of a specific kind
 func (ah *ArtifactHelper) isPartOfKind(part types.Part, kind string) bool {
-	switch p := part.(type) {
-	case types.TextPart:
-		return p.Kind == kind
-	case types.FilePart:
-		return p.Kind == kind
-	case types.DataPart:
-		return p.Kind == kind
-	case map[string]any:
-		if partKind, ok := p["kind"].(string); ok {
-			return partKind == kind
-		}
+	switch kind {
+	case "text":
+		return part.Text != nil
+	case "file":
+		return part.File != nil
+	case "data":
+		return part.Data != nil
 	}
 	return false
 }
 
 // extractFileFromPart extracts file data from a FilePart
 func (ah *ArtifactHelper) extractFileFromPart(filePart types.FilePart) (FileData, error) {
-	switch file := filePart.File.(type) {
-	case types.FileWithBytes:
-		data, err := base64.StdEncoding.DecodeString(file.Bytes)
-		if err != nil {
-			return FileData{}, fmt.Errorf("failed to decode base64 file data: %w", err)
-		}
-		return FileData{
-			Name:     file.Name,
-			MIMEType: file.MIMEType,
-			Data:     data,
-		}, nil
-	case types.FileWithUri:
-		return FileData{
-			Name:     file.Name,
-			MIMEType: file.MIMEType,
-			URI:      &file.URI,
-		}, nil
-	default:
-		return FileData{}, fmt.Errorf("unsupported file type: %T", file)
-	}
-}
-
-// extractFileFromMap extracts file data from a map representation
-func (ah *ArtifactHelper) extractFileFromMap(fileMap map[string]any) (FileData, error) {
-	fileData := FileData{}
-
-	fileContent, exists := fileMap["file"]
-	if !exists {
-		return FileData{}, fmt.Errorf("file map missing 'file' field")
+	fileData := FileData{
+		Name:     &filePart.Name,
+		MIMEType: &filePart.MediaType,
 	}
 
-	fileContentMap, ok := fileContent.(map[string]any)
-	if !ok {
-		return FileData{}, fmt.Errorf("file content is not a map")
-	}
-
-	if name, exists := fileContentMap["name"].(string); exists {
-		fileData.Name = &name
-	}
-
-	if mimeType, exists := fileContentMap["mimeType"].(string); exists {
-		fileData.MIMEType = &mimeType
-	}
-
-	if bytes, exists := fileContentMap["bytes"].(string); exists {
-		data, err := base64.StdEncoding.DecodeString(bytes)
+	// Check if it's a bytes-based file
+	if filePart.FileWithBytes != nil && *filePart.FileWithBytes != "" {
+		data, err := base64.StdEncoding.DecodeString(*filePart.FileWithBytes)
 		if err != nil {
 			return FileData{}, fmt.Errorf("failed to decode base64 file data: %w", err)
 		}
@@ -296,12 +225,13 @@ func (ah *ArtifactHelper) extractFileFromMap(fileMap map[string]any) (FileData, 
 		return fileData, nil
 	}
 
-	if uri, exists := fileContentMap["uri"].(string); exists {
-		fileData.URI = &uri
+	// Check if it's a URI-based file
+	if filePart.FileWithURI != nil && *filePart.FileWithURI != "" {
+		fileData.URI = filePart.FileWithURI
 		return fileData, nil
 	}
 
-	return FileData{}, fmt.Errorf("file content contains neither 'bytes' nor 'uri'")
+	return FileData{}, fmt.Errorf("file part contains neither bytes nor URI")
 }
 
 // ExtractArtifactUpdateFromStreamEvent extracts an artifact update event from a streaming event
@@ -350,17 +280,14 @@ func (ah *ArtifactHelper) GetArtifactSummary(task *types.Task) map[string]int {
 
 	for _, artifact := range task.Artifacts {
 		for _, part := range artifact.Parts {
-			switch p := part.(type) {
-			case types.TextPart:
-				summary[p.Kind]++
-			case types.FilePart:
-				summary[p.Kind]++
-			case types.DataPart:
-				summary[p.Kind]++
-			case map[string]any:
-				if kind, ok := p["kind"].(string); ok {
-					summary[kind]++
-				}
+			if part.Text != nil {
+				summary["text"]++
+			}
+			if part.File != nil {
+				summary["file"]++
+			}
+			if part.Data != nil {
+				summary["data"]++
 			}
 		}
 	}

--- a/client/artifact_helper_test.go
+++ b/client/artifact_helper_test.go
@@ -32,7 +32,7 @@ func TestArtifactHelper_ExtractTaskFromResponse(t *testing.T) {
 					ID:        "task-123",
 					ContextID: "context-456",
 					Status: types.TaskStatus{
-						State: string(types.TaskStateCompleted),
+						State: types.TaskStateCompleted,
 					},
 					Artifacts: []types.Artifact{
 						{

--- a/client/artifact_helper_test.go
+++ b/client/artifact_helper_test.go
@@ -39,7 +39,7 @@ func TestArtifactHelper_ExtractTaskFromResponse(t *testing.T) {
 							ArtifactID: "artifact-1",
 							Name:       stringPtr("Test Artifact"),
 							Parts: []types.Part{
-								types.TextPart{Kind: "text", Text: "Hello, World!"},
+								types.CreateTextPart("Hello, World!"),
 							},
 						},
 					},
@@ -104,14 +104,14 @@ func TestArtifactHelper_ExtractArtifactsFromTask(t *testing.T) {
 						ArtifactID: "artifact-1",
 						Name:       stringPtr("Artifact 1"),
 						Parts: []types.Part{
-							types.TextPart{Kind: "text", Text: "Content 1"},
+							{Text: stringPtr("Content 1")},
 						},
 					},
 					{
 						ArtifactID: "artifact-2",
 						Name:       stringPtr("Artifact 2"),
 						Parts: []types.Part{
-							types.TextPart{Kind: "text", Text: "Content 2"},
+							{Text: stringPtr("Content 2")},
 						},
 					},
 				},
@@ -202,26 +202,26 @@ func TestArtifactHelper_GetArtifactsByType(t *testing.T) {
 			{
 				ArtifactID: "text-artifact",
 				Parts: []types.Part{
-					types.TextPart{Kind: "text", Text: "Hello"},
+					{Text: stringPtr("Hello")},
 				},
 			},
 			{
 				ArtifactID: "file-artifact",
 				Parts: []types.Part{
-					types.FilePart{Kind: "file", File: types.FileWithBytes{Bytes: "dGVzdA=="}},
+					{File: &types.FilePart{FileWithBytes: stringPtr("dGVzdA=="), Name: "test.txt", MediaType: "text/plain"}},
 				},
 			},
 			{
 				ArtifactID: "data-artifact",
 				Parts: []types.Part{
-					types.DataPart{Kind: "data", Data: map[string]any{"key": "value"}},
+					{Data: &types.DataPart{}},
 				},
 			},
 			{
 				ArtifactID: "mixed-artifact",
 				Parts: []types.Part{
-					types.TextPart{Kind: "text", Text: "Mixed"},
-					types.DataPart{Kind: "data", Data: map[string]any{}},
+					{Text: stringPtr("Mixed")},
+					{Data: &types.DataPart{}},
 				},
 			},
 		},

--- a/client/artifact_helper_test.go
+++ b/client/artifact_helper_test.go
@@ -104,14 +104,14 @@ func TestArtifactHelper_ExtractArtifactsFromTask(t *testing.T) {
 						ArtifactID: "artifact-1",
 						Name:       stringPtr("Artifact 1"),
 						Parts: []types.Part{
-							{Text: stringPtr("Content 1")},
+							types.CreateTextPart("Content 1"),
 						},
 					},
 					{
 						ArtifactID: "artifact-2",
 						Name:       stringPtr("Artifact 2"),
 						Parts: []types.Part{
-							{Text: stringPtr("Content 2")},
+							types.CreateTextPart("Content 2"),
 						},
 					},
 				},
@@ -202,26 +202,26 @@ func TestArtifactHelper_GetArtifactsByType(t *testing.T) {
 			{
 				ArtifactID: "text-artifact",
 				Parts: []types.Part{
-					{Text: stringPtr("Hello")},
+					types.CreateTextPart("Hello"),
 				},
 			},
 			{
 				ArtifactID: "file-artifact",
 				Parts: []types.Part{
-					{File: &types.FilePart{FileWithBytes: stringPtr("dGVzdA=="), Name: "test.txt", MediaType: "text/plain"}},
+					types.CreateFilePart("test.txt", "text/plain", stringPtr("dGVzdA=="), nil),
 				},
 			},
 			{
 				ArtifactID: "data-artifact",
 				Parts: []types.Part{
-					{Data: &types.DataPart{}},
+					types.CreateDataPart(map[string]any{}),
 				},
 			},
 			{
 				ArtifactID: "mixed-artifact",
 				Parts: []types.Part{
-					{Text: stringPtr("Mixed")},
-					{Data: &types.DataPart{}},
+					types.CreateTextPart("Mixed"),
+					types.CreateDataPart(map[string]any{}),
 				},
 			},
 		},

--- a/client/client.go
+++ b/client/client.go
@@ -128,7 +128,7 @@ func (c *Client) SendTask(ctx context.Context, params types.MessageSendParams) (
 	c.logger.Debug("sending task",
 		zap.String("method", "message/send"),
 		zap.String("message_id", params.Message.MessageID),
-		zap.String("role", params.Message.Role))
+		zap.String("role", string(params.Message.Role)))
 
 	req := types.JSONRPCRequest{
 		JSONRPC: "2.0",
@@ -164,7 +164,7 @@ func (c *Client) SendTaskStreaming(ctx context.Context, params types.MessageSend
 	c.logger.Debug("starting task streaming",
 		zap.String("method", "message/stream"),
 		zap.String("message_id", params.Message.MessageID),
-		zap.String("role", params.Message.Role))
+		zap.String("role", string(params.Message.Role)))
 
 	req := types.JSONRPCRequest{
 		JSONRPC: "2.0",

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -444,7 +444,7 @@ func TestClient_GetTask(t *testing.T) {
 								"message": map[string]any{
 									"kind":      "message",
 									"messageId": "response-msg",
-									"role":      "assistant",
+									"role":      "ROLE_AGENT",
 									"parts": []any{
 										map[string]any{
 											"kind": "text",
@@ -1324,7 +1324,7 @@ func TestClient_LargeResponses(t *testing.T) {
 					"message": map[string]any{
 						"kind":      "message",
 						"messageId": "large-response",
-						"role":      "assistant",
+						"role":      "ROLE_AGENT",
 						"parts": []any{
 							map[string]any{
 								"kind": "text",

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -302,10 +302,7 @@ func TestClient_SendTask(t *testing.T) {
 					MessageID: "test-msg-1",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Hello, world!",
-						},
+						types.CreateTextPart("Hello, world!"),
 					},
 				},
 			},
@@ -357,10 +354,7 @@ func TestClient_SendTask(t *testing.T) {
 					MessageID: "test-msg-500",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "This should fail",
-						},
+						types.CreateTextPart("This should fail"),
 					},
 				},
 			},
@@ -383,10 +377,7 @@ func TestClient_SendTask(t *testing.T) {
 					MessageID: "test-msg-invalid",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Invalid response test",
-						},
+						types.CreateTextPart("Invalid response test"),
 					},
 				},
 			},
@@ -781,10 +772,7 @@ func TestClient_SendTaskStreaming(t *testing.T) {
 					MessageID: "stream-msg-1",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Stream this message",
-						},
+						types.CreateTextPart("Stream this message"),
 					},
 				},
 			},
@@ -805,10 +793,7 @@ func TestClient_SendTaskStreaming(t *testing.T) {
 					MessageID: "stream-error",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "This should fail",
-						},
+						types.CreateTextPart("This should fail"),
 					},
 				},
 			},
@@ -830,10 +815,7 @@ func TestClient_SendTaskStreaming(t *testing.T) {
 					MessageID: "stream-invalid",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Invalid stream test",
-						},
+						types.CreateTextPart("Invalid stream test"),
 					},
 				},
 			},
@@ -857,10 +839,7 @@ func TestClient_SendTaskStreaming(t *testing.T) {
 					MessageID: "stream-empty",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Empty stream test",
-						},
+						types.CreateTextPart("Empty stream test"),
 					},
 				},
 			},
@@ -1029,10 +1008,7 @@ func TestClient_RetryMechanism(t *testing.T) {
 					MessageID: "retry-test",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Testing retry mechanism",
-						},
+						types.CreateTextPart("Testing retry mechanism"),
 					},
 				},
 			}
@@ -1147,10 +1123,7 @@ func TestClient_ContextCancellation(t *testing.T) {
 					MessageID: "context-test",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Testing context cancellation",
-						},
+						types.CreateTextPart("Testing context cancellation"),
 					},
 				},
 			}
@@ -1308,10 +1281,7 @@ func TestClient_HeadersAndAuthentication(t *testing.T) {
 					MessageID: "header-test",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Testing headers",
-						},
+						types.CreateTextPart("Testing headers"),
 					},
 				},
 			}
@@ -1382,10 +1352,7 @@ func TestClient_LargeResponses(t *testing.T) {
 			MessageID: "large-test",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Request large response",
-				},
+				types.CreateTextPart("Request large response"),
 			},
 		},
 	}
@@ -1428,10 +1395,7 @@ func TestClient_ConcurrentRequests(t *testing.T) {
 					MessageID: fmt.Sprintf("concurrent-msg-%d", index),
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": fmt.Sprintf("Concurrent request %d", index),
-						},
+						types.CreateTextPart(fmt.Sprintf("Concurrent request %d", index)),
 					},
 				},
 			}
@@ -1473,7 +1437,7 @@ func TestClient_GetAgentCard(t *testing.T) {
 						Name:        "test-agent",
 						Description: "A test agent for demonstration",
 						Version:     "0.1.0",
-						URL:         "https://example.com",
+						URL:         &[]string{"https://example.com"}[0],
 						Capabilities: types.AgentCapabilities{
 							Streaming:              &[]bool{true}[0],
 							PushNotifications:      &[]bool{false}[0],
@@ -1496,7 +1460,7 @@ func TestClient_GetAgentCard(t *testing.T) {
 				Name:        "test-agent",
 				Description: "A test agent for demonstration",
 				Version:     "0.1.0",
-				URL:         "https://example.com",
+				URL:         &[]string{"https://example.com"}[0],
 				Capabilities: types.AgentCapabilities{
 					Streaming:              &[]bool{true}[0],
 					PushNotifications:      &[]bool{false}[0],
@@ -1748,22 +1712,20 @@ func TestClient_ListTasks(t *testing.T) {
 					ID:        "task-1",
 					ContextID: "context-1",
 					Status: types.TaskStatus{
-						State: types.TaskStateCompleted,
+						State: string(types.TaskStateCompleted),
 					},
-					Kind: "task",
 				},
 				{
 					ID:        "task-2",
 					ContextID: "context-1",
 					Status: types.TaskStatus{
-						State: types.TaskStateWorking,
+						State: string(types.TaskStateWorking),
 					},
-					Kind: "task",
 				},
 			},
-			Total:  2,
-			Limit:  50,
-			Offset: 0,
+			TotalSize: 2,
+			PageSize:  50,
+			
 		}
 
 		response := types.JSONRPCSuccessResponse{
@@ -1784,8 +1746,7 @@ func TestClient_ListTasks(t *testing.T) {
 
 	t.Run("successful_tasks_list", func(t *testing.T) {
 		params := types.TaskListParams{
-			Limit:  50,
-			Offset: 0,
+			Limit: 50,
 		}
 
 		resp, err := a2aClient.ListTasks(context.Background(), params)
@@ -1801,9 +1762,8 @@ func TestClient_ListTasks(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, len(taskList.Tasks))
-		assert.Equal(t, 2, taskList.Total)
-		assert.Equal(t, 50, taskList.Limit)
-		assert.Equal(t, 0, taskList.Offset)
+		assert.Equal(t, 2, taskList.TotalSize)
+		assert.Equal(t, 50, taskList.PageSize)
 		assert.Equal(t, "task-1", taskList.Tasks[0].ID)
 		assert.Equal(t, types.TaskStateCompleted, taskList.Tasks[0].Status.State)
 	})
@@ -1813,7 +1773,7 @@ func TestClient_ListTasks(t *testing.T) {
 		params := types.TaskListParams{
 			State:  &completedState,
 			Limit:  10,
-			Offset: 0,
+			
 		}
 
 		resp, err := a2aClient.ListTasks(context.Background(), params)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -299,7 +299,6 @@ func TestClient_SendTask(t *testing.T) {
 			},
 			params: types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "test-msg-1",
 					Role:      "user",
 					Parts: []types.Part{
@@ -335,7 +334,6 @@ func TestClient_SendTask(t *testing.T) {
 			},
 			params: types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "test-msg-error",
 					Role:      "user",
 					Parts:     []types.Part{},
@@ -356,7 +354,6 @@ func TestClient_SendTask(t *testing.T) {
 			},
 			params: types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "test-msg-500",
 					Role:      "user",
 					Parts: []types.Part{
@@ -383,7 +380,6 @@ func TestClient_SendTask(t *testing.T) {
 			},
 			params: types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "test-msg-invalid",
 					Role:      "user",
 					Parts: []types.Part{
@@ -782,7 +778,6 @@ func TestClient_SendTaskStreaming(t *testing.T) {
 			},
 			params: types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "stream-msg-1",
 					Role:      "user",
 					Parts: []types.Part{
@@ -807,7 +802,6 @@ func TestClient_SendTaskStreaming(t *testing.T) {
 			},
 			params: types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "stream-error",
 					Role:      "user",
 					Parts: []types.Part{
@@ -833,7 +827,6 @@ func TestClient_SendTaskStreaming(t *testing.T) {
 			},
 			params: types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "stream-invalid",
 					Role:      "user",
 					Parts: []types.Part{
@@ -861,7 +854,6 @@ func TestClient_SendTaskStreaming(t *testing.T) {
 			},
 			params: types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "stream-empty",
 					Role:      "user",
 					Parts: []types.Part{
@@ -1034,7 +1026,6 @@ func TestClient_RetryMechanism(t *testing.T) {
 
 			params := types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "retry-test",
 					Role:      "user",
 					Parts: []types.Part{
@@ -1153,7 +1144,6 @@ func TestClient_ContextCancellation(t *testing.T) {
 
 			params := types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "context-test",
 					Role:      "user",
 					Parts: []types.Part{
@@ -1315,7 +1305,6 @@ func TestClient_HeadersAndAuthentication(t *testing.T) {
 			ctx := context.Background()
 			params := types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: "header-test",
 					Role:      "user",
 					Parts: []types.Part{
@@ -1390,7 +1379,6 @@ func TestClient_LargeResponses(t *testing.T) {
 
 	params := types.MessageSendParams{
 		Message: types.Message{
-			Kind:      "message",
 			MessageID: "large-test",
 			Role:      "user",
 			Parts: []types.Part{
@@ -1437,7 +1425,6 @@ func TestClient_ConcurrentRequests(t *testing.T) {
 		go func(index int) {
 			params := types.MessageSendParams{
 				Message: types.Message{
-					Kind:      "message",
 					MessageID: fmt.Sprintf("concurrent-msg-%d", index),
 					Role:      "user",
 					Parts: []types.Part{

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1712,20 +1712,19 @@ func TestClient_ListTasks(t *testing.T) {
 					ID:        "task-1",
 					ContextID: "context-1",
 					Status: types.TaskStatus{
-						State: string(types.TaskStateCompleted),
+						State: types.TaskStateCompleted,
 					},
 				},
 				{
 					ID:        "task-2",
 					ContextID: "context-1",
 					Status: types.TaskStatus{
-						State: string(types.TaskStateWorking),
+						State: types.TaskStateWorking,
 					},
 				},
 			},
 			TotalSize: 2,
 			PageSize:  50,
-			
 		}
 
 		response := types.JSONRPCSuccessResponse{
@@ -1771,9 +1770,8 @@ func TestClient_ListTasks(t *testing.T) {
 	t.Run("list_tasks_with_filtering", func(t *testing.T) {
 		completedState := types.TaskStateCompleted
 		params := types.TaskListParams{
-			State:  &completedState,
-			Limit:  10,
-			
+			State: &completedState,
+			Limit: 10,
 		}
 
 		resp, err := a2aClient.ListTasks(context.Background(), params)

--- a/examples/ai-powered-streaming/client/main.go
+++ b/examples/ai-powered-streaming/client/main.go
@@ -23,8 +23,8 @@ type Config struct {
 // extractTextFromParts extracts text from message parts
 func extractTextFromParts(parts []types.Part) string {
 	for _, part := range parts {
-		if textPart, ok := part.(types.TextPart); ok {
-			return textPart.Text
+		if part.Text != nil {
+			return *part.Text
 		}
 	}
 	return ""
@@ -74,12 +74,9 @@ func main() {
 		fmt.Printf("%d️⃣ STREAMING: %s\n", i+1, task.name)
 
 		message := types.Message{
-			Role: "user",
+			Role: types.RoleUser,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: task.text,
-				},
+				types.CreateTextPart(task.text),
 			},
 		}
 

--- a/examples/ai-powered-streaming/server/main.go
+++ b/examples/ai-powered-streaming/server/main.go
@@ -67,7 +67,6 @@ func (h *AIStreamingTaskHandler) HandleTask(ctx context.Context, task *types.Tas
 
 	// Create final response message
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("msg-%s", task.ID),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,

--- a/examples/ai-powered/client/main.go
+++ b/examples/ai-powered/client/main.go
@@ -65,12 +65,9 @@ func main() {
 
 		// Create message with proper structure
 		message := types.Message{
-			Role: "user",
+			Role: types.RoleUser,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: prompt,
-				},
+				types.CreateTextPart(prompt),
 			},
 		}
 
@@ -136,8 +133,8 @@ func main() {
 				// Display the response
 				if task.Status.Message != nil {
 					for _, part := range task.Status.Message.Parts {
-						if textPart, ok := part.(types.TextPart); ok {
-							fmt.Printf("\nResponse: %s\n", textPart.Text)
+						if part.Text != nil {
+							fmt.Printf("\nResponse: %s\n", *part.Text)
 						}
 					}
 				}

--- a/examples/ai-powered/server/main.go
+++ b/examples/ai-powered/server/main.go
@@ -66,7 +66,6 @@ func (h *AITaskHandler) HandleTask(ctx context.Context, task *types.Task, messag
 
 	// Create final response message
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("msg-%s", task.ID),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,

--- a/examples/ai-powered/server/main.go
+++ b/examples/ai-powered/server/main.go
@@ -53,8 +53,8 @@ func (h *AITaskHandler) HandleTask(ctx context.Context, task *types.Task, messag
 			var deltaMsg types.Message
 			if err := cloudEvent.DataAs(&deltaMsg); err == nil {
 				for _, part := range deltaMsg.Parts {
-					if textPart, ok := part.(types.TextPart); ok {
-						fullResponse += textPart.Text
+					if part.Text != nil {
+						fullResponse += *part.Text
 					}
 				}
 			}
@@ -69,12 +69,9 @@ func (h *AITaskHandler) HandleTask(ctx context.Context, task *types.Task, messag
 		MessageID: fmt.Sprintf("msg-%s", task.ID),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: fullResponse,
-			},
+			types.CreateTextPart(fullResponse),
 		},
 	}
 
@@ -225,6 +222,7 @@ func main() {
 	taskHandler.SetAgent(agent)
 
 	// Build and start server
+	agentURL := fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)
 	a2aServer, err := server.NewA2AServerBuilder(cfg.A2A, logger).
 		WithBackgroundTaskHandler(taskHandler).
 		WithDefaultStreamingTaskHandler().
@@ -232,7 +230,7 @@ func main() {
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             &agentURL,
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,

--- a/examples/artifacts-autonomous-tool/client/main.go
+++ b/examples/artifacts-autonomous-tool/client/main.go
@@ -128,12 +128,9 @@ func processPrompt(ctx context.Context, a2aClient client.A2AClient, prompt, down
 // sendTask sends a message and returns the task ID
 func sendTask(ctx context.Context, a2aClient client.A2AClient, prompt string) (string, error) {
 	message := types.Message{
-		Role: "user",
+		Role: types.RoleUser,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: prompt,
-			},
+			types.CreateTextPart(prompt),
 		},
 	}
 
@@ -225,8 +222,8 @@ func displayResponse(task *types.Task) {
 	}
 
 	for _, part := range task.Status.Message.Parts {
-		if textPart, ok := part.(types.TextPart); ok {
-			fmt.Printf("\nResponse: %s\n", textPart.Text)
+		if part.Text != nil {
+			fmt.Printf("\nResponse: %s\n", *part.Text)
 		}
 	}
 }

--- a/examples/artifacts-autonomous-tool/server/main.go
+++ b/examples/artifacts-autonomous-tool/server/main.go
@@ -174,7 +174,7 @@ Be efficient and proactive in creating artifacts.`).
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -232,4 +232,9 @@ Be efficient and proactive in creating artifacts.`).
 	if err := artifactsServer.Stop(shutdownCtx); err != nil {
 		logger.Error("artifacts server shutdown error", zap.Error(err))
 	}
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/artifacts-filesystem/client/main.go
+++ b/examples/artifacts-filesystem/client/main.go
@@ -148,8 +148,8 @@ func main() {
 	if completedTask.Status.Message != nil {
 		fmt.Println("\n📄 Response from server:")
 		for _, part := range completedTask.Status.Message.Parts {
-			if textPart, ok := part.(types.TextPart); ok {
-				fmt.Printf("   %s\n", textPart.Text)
+			if part.Text != nil {
+				fmt.Printf("   %s\n", *part.Text)
 			}
 		}
 	}
@@ -212,12 +212,9 @@ func createMessageWithFileUpload() types.Message {
 		fmt.Printf("❌ Failed to read data file: %v\n", err)
 		fmt.Println("Using default text message instead...")
 		return types.Message{
-			Role: "user",
+			Role: types.RoleUser,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: "Please create a detailed analysis report about renewable energy trends in 2024. Include charts and recommendations.",
-				},
+				types.CreateTextPart("Please create a detailed analysis report about renewable energy trends in 2024. Include charts and recommendations."),
 			},
 		}
 	}
@@ -237,20 +234,10 @@ func createMessageWithFileUpload() types.Message {
 
 	// Create message with both text and file parts
 	return types.Message{
-		Role: "user",
+		Role: types.RoleUser,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: "Please analyze the uploaded energy data and create a comprehensive report with insights and recommendations based on the provided statistics.",
-			},
-			types.FilePart{
-				Kind: "file",
-				File: map[string]any{
-					"bytes":    encodedContent,
-					"mimeType": mimeType,
-					"name":     filename,
-				},
-			},
+			types.CreateTextPart("Please analyze the uploaded energy data and create a comprehensive report with insights and recommendations based on the provided statistics."),
+			types.CreateFilePart(filename, mimeType, &encodedContent, nil),
 		},
 	}
 }

--- a/examples/artifacts-filesystem/server/main.go
+++ b/examples/artifacts-filesystem/server/main.go
@@ -155,7 +155,6 @@ func (h *ArtifactsTaskHandler) HandleTask(ctx context.Context, task *types.Task,
 	responseText := fmt.Sprintf("I've created an analysis report for your request: \"%s\". The report has been saved as an artifact and is available for download.", userText)
 
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: uuid.New().String(),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,

--- a/examples/artifacts-filesystem/server/main.go
+++ b/examples/artifacts-filesystem/server/main.go
@@ -54,20 +54,16 @@ func extractMessageContent(message *types.Message) (string, string, string) {
 
 	for _, part := range message.Parts {
 		// Extract text content
-		if textPart, ok := part.(types.TextPart); ok {
-			userText = textPart.Text
+		if part.Text != nil {
+			userText = *part.Text
 		}
 
 		// Extract file content
-		if filePart, ok := part.(types.FilePart); ok {
-			if fileData, ok := filePart.File.(map[string]any); ok {
-				if name, ok := fileData["name"].(string); ok {
-					fileName = name
-				}
-				if bytes, ok := fileData["bytes"].(string); ok {
-					if decoded, err := base64.StdEncoding.DecodeString(bytes); err == nil {
-						fileContent = string(decoded)
-					}
+		if part.File != nil {
+			fileName = part.File.Name
+			if part.File.FileWithBytes != nil {
+				if decoded, err := base64.StdEncoding.DecodeString(*part.File.FileWithBytes); err == nil {
+					fileContent = string(decoded)
 				}
 			}
 		}
@@ -158,12 +154,9 @@ func (h *ArtifactsTaskHandler) HandleTask(ctx context.Context, task *types.Task,
 		MessageID: uuid.New().String(),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: responseText,
-			},
+			types.CreateTextPart(responseText),
 		},
 	}
 
@@ -299,7 +292,7 @@ func main() {
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -355,4 +348,9 @@ func main() {
 	if err := artifactsServer.Stop(shutdownCtx); err != nil {
 		logger.Error("artifacts server shutdown error", zap.Error(err))
 	}
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/artifacts-minio/client/main.go
+++ b/examples/artifacts-minio/client/main.go
@@ -150,8 +150,8 @@ func main() {
 	if completedTask.Status.Message != nil {
 		fmt.Println("\n📄 Response from server:")
 		for _, part := range completedTask.Status.Message.Parts {
-			if textPart, ok := part.(types.TextPart); ok {
-				fmt.Printf("   %s\n", textPart.Text)
+			if part.Text != nil {
+				fmt.Printf("   %s\n", *part.Text)
 			}
 		}
 	}
@@ -219,12 +219,9 @@ func createMessageWithFileUpload() types.Message {
 		fmt.Printf("❌ Failed to read data file: %v\n", err)
 		fmt.Println("Using default text message instead...")
 		return types.Message{
-			Role: "user",
+			Role: types.RoleUser,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: "Please create a detailed analysis report about renewable energy trends in 2024. Include charts and recommendations. This will be stored in MinIO cloud storage.",
-				},
+				types.CreateTextPart("Please create a detailed analysis report about renewable energy trends in 2024. Include charts and recommendations. This will be stored in MinIO cloud storage."),
 			},
 		}
 	}
@@ -244,20 +241,10 @@ func createMessageWithFileUpload() types.Message {
 
 	// Create message with both text and file parts
 	return types.Message{
-		Role: "user",
+		Role: types.RoleUser,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: "Please analyze the uploaded energy data and create a comprehensive report with insights and recommendations based on the provided statistics. The report will be stored in MinIO cloud storage for scalable access.",
-			},
-			types.FilePart{
-				Kind: "file",
-				File: map[string]any{
-					"bytes":    encodedContent,
-					"mimeType": mimeType,
-					"name":     filename,
-				},
-			},
+			types.CreateTextPart("Please analyze the uploaded energy data and create a comprehensive report with insights and recommendations based on the provided statistics. The report will be stored in MinIO cloud storage for scalable access."),
+			types.CreateFilePart(filename, mimeType, &encodedContent, nil),
 		},
 	}
 }

--- a/examples/artifacts-minio/server/main.go
+++ b/examples/artifacts-minio/server/main.go
@@ -160,7 +160,6 @@ func (h *ArtifactsTaskHandler) HandleTask(ctx context.Context, task *types.Task,
 	responseText := fmt.Sprintf("I've created an analysis report for your request: \"%s\". The report has been saved as an artifact in MinIO cloud storage and is available for download.", userText)
 
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: uuid.New().String(),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,

--- a/examples/artifacts-minio/server/main.go
+++ b/examples/artifacts-minio/server/main.go
@@ -54,20 +54,16 @@ func extractMessageContent(message *types.Message) (string, string, string) {
 
 	for _, part := range message.Parts {
 		// Extract text content
-		if textPart, ok := part.(types.TextPart); ok {
-			userText = textPart.Text
+		if part.Text != nil {
+			userText = *part.Text
 		}
 
 		// Extract file content
-		if filePart, ok := part.(types.FilePart); ok {
-			if fileData, ok := filePart.File.(map[string]any); ok {
-				if name, ok := fileData["name"].(string); ok {
-					fileName = name
-				}
-				if bytes, ok := fileData["bytes"].(string); ok {
-					if decoded, err := base64.StdEncoding.DecodeString(bytes); err == nil {
-						fileContent = string(decoded)
-					}
+		if part.File != nil {
+			fileName = part.File.Name
+			if part.File.FileWithBytes != nil {
+				if decoded, err := base64.StdEncoding.DecodeString(*part.File.FileWithBytes); err == nil {
+					fileContent = string(decoded)
 				}
 			}
 		}
@@ -163,12 +159,9 @@ func (h *ArtifactsTaskHandler) HandleTask(ctx context.Context, task *types.Task,
 		MessageID: uuid.New().String(),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: responseText,
-			},
+			types.CreateTextPart(responseText),
 		},
 	}
 
@@ -312,7 +305,7 @@ func main() {
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -368,4 +361,9 @@ func main() {
 	if err := artifactsServer.Stop(shutdownCtx); err != nil {
 		logger.Error("artifacts server shutdown error", zap.Error(err))
 	}
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/artifacts-with-default-handlers/client/main.go
+++ b/examples/artifacts-with-default-handlers/client/main.go
@@ -71,10 +71,7 @@ func main() {
 func runTest(a2aClient client.A2AClient, logger *zap.Logger, prompt string, includeFile bool) {
 	// Create message parts
 	parts := []types.Part{
-		types.TextPart{
-			Kind: "text",
-			Text: prompt,
-		},
+		types.CreateTextPart(prompt),
 	}
 
 	// Add file upload for first test
@@ -99,19 +96,12 @@ Total Renewable Energy: 3,615 GWh`
 		encodedContent := base64.StdEncoding.EncodeToString([]byte(fileContent))
 		filename := "energy_data_2024.txt"
 		mimeType := "text/plain"
-		parts = append(parts, types.FilePart{
-			Kind: "file",
-			File: map[string]any{
-				"bytes":    encodedContent,
-				"mimeType": mimeType,
-				"name":     filename,
-			},
-		})
+		parts = append(parts, types.CreateFilePart(filename, mimeType, &encodedContent, nil))
 		logger.Info("uploading file", zap.String("filename", "energy_data_2024.txt"), zap.Int("size_bytes", len(fileContent)))
 	}
 
 	message := types.Message{
-		Role:  "user",
+		Role:  types.RoleUser,
 		Parts: parts,
 	}
 

--- a/examples/artifacts-with-default-handlers/server/main.go
+++ b/examples/artifacts-with-default-handlers/server/main.go
@@ -688,7 +688,7 @@ note over User,Database : %s
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -757,4 +757,9 @@ note over User,Database : %s
 	if err := artifactsServer.Stop(shutdownCtx); err != nil {
 		logger.Error("artifacts server shutdown error", zap.Error(err))
 	}
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/callbacks/server/main.go
+++ b/examples/callbacks/server/main.go
@@ -65,7 +65,7 @@ func (h *CallbacksTaskHandler) HandleTask(ctx context.Context, task *types.Task,
 		MessageID: fmt.Sprintf("msg-%s", task.ID),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
 			types.CreateTextPart(fullResponse),
 		},

--- a/examples/callbacks/server/main.go
+++ b/examples/callbacks/server/main.go
@@ -62,7 +62,6 @@ func (h *CallbacksTaskHandler) HandleTask(ctx context.Context, task *types.Task,
 	}
 
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("msg-%s", task.ID),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,

--- a/examples/callbacks/server/main.go
+++ b/examples/callbacks/server/main.go
@@ -71,7 +71,7 @@ func (h *CallbacksTaskHandler) HandleTask(ctx context.Context, task *types.Task,
 		},
 	}
 
-	task.Status.State = string(types.TaskStateCompleted)
+	task.Status.State = types.TaskStateCompleted
 	task.Status.Message = &responseMessage
 	task.History = append(task.History, responseMessage)
 

--- a/examples/default-handlers/README.md
+++ b/examples/default-handlers/README.md
@@ -132,7 +132,7 @@ Response:
   "status": {
     "state": "completed",
     "message": {
-      "role": "assistant",
+      "role": "ROLE_AGENT",
       "parts": [
         {
           "kind": "text",

--- a/examples/default-handlers/client/main.go
+++ b/examples/default-handlers/client/main.go
@@ -157,7 +157,7 @@ func main() {
 						fmt.Printf("Partial Response:\n%s\n", string(messageJSON))
 					}
 					completed = true
-				case types.TaskStateFailed, types.TaskStateCanceled, types.TaskStateRejected:
+				case types.TaskStateFailed, types.TaskStateCancelled, types.TaskStateRejected:
 					logger.Warn("task ended", zap.String("state", string(task.Status.State)))
 					if task.Status.Message != nil {
 						messageJSON, _ := json.MarshalIndent(task.Status.Message, "", "  ")

--- a/examples/default-handlers/client/main.go
+++ b/examples/default-handlers/client/main.go
@@ -65,12 +65,9 @@ func main() {
 
 		// Create message with proper structure
 		message := types.Message{
-			Role: "user",
+			Role: types.RoleUser,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: prompt,
-				},
+				types.CreateTextPart(prompt),
 			},
 		}
 

--- a/examples/default-handlers/server/main.go
+++ b/examples/default-handlers/server/main.go
@@ -147,7 +147,7 @@ func main() {
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -189,4 +189,9 @@ func main() {
 	if err := a2aServer.Stop(shutdownCtx); err != nil {
 		logger.Error("shutdown error", zap.Error(err))
 	}
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/input-required/non-streaming/client/main.go
+++ b/examples/input-required/non-streaming/client/main.go
@@ -87,9 +87,9 @@ func demonstrateInputRequiredFlow(a2aClient client.A2AClient, initialMessage str
 	// Create initial message
 	message := types.Message{
 		MessageID: fmt.Sprintf("msg-%d", time.Now().UnixNano()),
-		Role:      "user",
+		Role:      types.RoleUser,
 		Parts: []types.Part{
-			types.NewTextPart(initialMessage),
+			types.CreateTextPart(initialMessage),
 		},
 	}
 
@@ -181,9 +181,9 @@ func demonstrateInputRequiredFlow(a2aClient client.A2AClient, initialMessage str
 			followUpMessage := types.Message{
 				MessageID: fmt.Sprintf("msg-%d", time.Now().UnixNano()),
 				ContextID: &contextID,
-				Role:      "user",
+				Role:      types.RoleUser,
 				Parts: []types.Part{
-					types.NewTextPart(userResponse),
+					types.CreateTextPart(userResponse),
 				},
 			}
 
@@ -244,17 +244,8 @@ func demonstrateInputRequiredFlow(a2aClient client.A2AClient, initialMessage str
 // extractMessageText extracts text content from a message
 func extractMessageText(message *types.Message) string {
 	for _, part := range message.Parts {
-		// Handle typed TextPart (when created locally)
-		if textPart, ok := part.(types.TextPart); ok {
-			return textPart.Text
-		}
-		// Handle map-based parts (when deserialized from JSON)
-		if partMap, ok := part.(map[string]any); ok {
-			if kind, exists := partMap["kind"]; exists && kind == "text" {
-				if text, exists := partMap["text"].(string); exists {
-					return text
-				}
-			}
+		if part.Text != nil {
+			return *part.Text
 		}
 	}
 	return "(no text content)"

--- a/examples/input-required/non-streaming/client/main.go
+++ b/examples/input-required/non-streaming/client/main.go
@@ -224,7 +224,7 @@ func demonstrateInputRequiredFlow(a2aClient client.A2AClient, initialMessage str
 			}
 			return nil
 
-		case types.TaskStateCanceled:
+		case types.TaskStateCancelled:
 			// Task was canceled
 			fmt.Printf("🚫 Task Canceled\n\n")
 			return nil

--- a/examples/input-required/non-streaming/server/main.go
+++ b/examples/input-required/non-streaming/server/main.go
@@ -214,7 +214,6 @@ func (h *InputRequiredTaskHandler) processWithoutAgent(ctx context.Context, task
 		// Request location if not provided
 		if !contains(messageText, "in ") && !contains(messageText, "at ") {
 			inputMessage := &types.Message{
-				Kind:      "input_required",
 				MessageID: fmt.Sprintf("input-required-%s", task.ID),
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -253,7 +252,6 @@ func (h *InputRequiredTaskHandler) processWithoutAgent(ctx context.Context, task
 		// Request specific numbers if not provided
 		if !hasNumbers(messageText) {
 			inputMessage := &types.Message{
-				Kind:      "input_required",
 				MessageID: fmt.Sprintf("input-required-%s", task.ID),
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -308,7 +306,6 @@ func (h *InputRequiredTaskHandler) processWithoutAgent(ctx context.Context, task
 	default:
 		// For unclear requests, ask for clarification
 		inputMessage := &types.Message{
-			Kind:      "input_required",
 			MessageID: fmt.Sprintf("input-required-%s", task.ID),
 			Role:      "assistant",
 			Parts: []types.Part{

--- a/examples/input-required/non-streaming/server/main.go
+++ b/examples/input-required/non-streaming/server/main.go
@@ -74,7 +74,6 @@ func (h *InputRequiredTaskHandler) processWithAgent(ctx context.Context, task *t
 		h.logger.Error("agent processing failed", zap.Error(err))
 		task.Status.State = types.TaskStateFailed
 		task.Status.Message = &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("error-%s", task.ID),
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -139,7 +138,6 @@ func (h *InputRequiredTaskHandler) processWithAgent(ctx context.Context, task *t
 		// No clear result, mark as failed
 		task.Status.State = types.TaskStateFailed
 		task.Status.Message = &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("error-%s", task.ID),
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -177,7 +175,6 @@ func (h *InputRequiredTaskHandler) processWithoutAgent(ctx context.Context, task
 		case "weather":
 			// User provided location for weather query
 			responseMessage := &types.Message{
-				Kind:      "message",
 				MessageID: fmt.Sprintf("response-%s", task.ID),
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -195,7 +192,6 @@ func (h *InputRequiredTaskHandler) processWithoutAgent(ctx context.Context, task
 		case "calculate":
 			// User provided calculation
 			responseMessage := &types.Message{
-				Kind:      "message",
 				MessageID: fmt.Sprintf("response-%s", task.ID),
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -239,7 +235,6 @@ func (h *InputRequiredTaskHandler) processWithoutAgent(ctx context.Context, task
 
 		// If location is provided, give weather response
 		responseMessage := &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("response-%s", task.ID),
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -279,7 +274,6 @@ func (h *InputRequiredTaskHandler) processWithoutAgent(ctx context.Context, task
 
 		// If numbers are provided, give calculation response
 		responseMessage := &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("response-%s", task.ID),
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -297,7 +291,6 @@ func (h *InputRequiredTaskHandler) processWithoutAgent(ctx context.Context, task
 	case contains(messageText, "hello") || contains(messageText, "hi"):
 		// Simple greeting, no input required
 		responseMessage := &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("response-%s", task.ID),
 			Role:      "assistant",
 			Parts: []types.Part{

--- a/examples/input-required/streaming/README.md
+++ b/examples/input-required/streaming/README.md
@@ -195,7 +195,7 @@ func (h *StreamingInputRequiredTaskHandler) sendStreamingText(outputChan chan<- 
     // Split text into chunks for realistic streaming
     words := strings.Fields(text)
     for _, word := range words {
-        deltaMessage := &types.Message{Kind: "message", ...}
+        deltaMessage := &types.Message{...}
         event := types.NewDeltaEvent(deltaMessage)
         outputChan <- event
         time.Sleep(50 * time.Millisecond) // Simulate typing

--- a/examples/input-required/streaming/client/main.go
+++ b/examples/input-required/streaming/client/main.go
@@ -128,59 +128,53 @@ func demonstrateStreamingInputRequiredFlow(a2aClient client.A2AClient, initialMe
 
 		resultBytes, _ := json.Marshal(event.Result)
 
-		// Try to parse as Task (for delta events)
+		// Check if this is a delta event (contains message parts to stream)
 		var task types.Task
-		if err := json.Unmarshal(resultBytes, &task); err == nil && task.Kind == "task" {
+		if err := json.Unmarshal(resultBytes, &task); err == nil && task.Status.Message != nil {
 			// Handle delta message - display text in real-time
-			if task.Status.Message != nil && len(task.Status.Message.Parts) > 0 {
+			if len(task.Status.Message.Parts) > 0 {
 				text := extractMessageText(task.Status.Message)
-				fmt.Print(text)
-				streamingText.WriteString(text)
+				if text != "" {
+					fmt.Print(text)
+					streamingText.WriteString(text)
+				}
 			}
-			continue
 		}
 
-		// Try to parse as TaskStatusUpdateEvent (for status changes)
+		// Check for status updates
 		var statusUpdate types.TaskStatusUpdateEvent
-		if err := json.Unmarshal(resultBytes, &statusUpdate); err != nil {
-			logger.Debug("failed to parse event", zap.Error(err))
-			continue
-		}
+		if err := json.Unmarshal(resultBytes, &statusUpdate); err == nil && statusUpdate.TaskID != "" {
+			// Handle different task states
+			switch statusUpdate.Status.State {
+			case types.TaskStateWorking:
+				logger.Info("task started")
 
-		if statusUpdate.Kind != "status-update" {
-			continue
-		}
+			case types.TaskStateCompleted:
+				logger.Info("task completed")
+				taskCompleted = true
 
-		// Handle different task states
-		switch statusUpdate.Status.State {
-		case types.TaskStateWorking:
-			logger.Info("task started")
+			case types.TaskStateInputRequired:
+				logger.Info("input required")
+				taskInputRequired = true
+				currentTaskID = statusUpdate.TaskID
+				currentContextID = statusUpdate.ContextID
+				if statusUpdate.Status.Message != nil {
+					inputRequiredMessage = extractMessageText(statusUpdate.Status.Message)
+				}
 
-		case types.TaskStateCompleted:
-			logger.Info("task completed")
-			taskCompleted = true
+			case types.TaskStateFailed:
+				logger.Error("task failed")
+				fmt.Print("\n❌ Task failed")
+				return nil
 
-		case types.TaskStateInputRequired:
-			logger.Info("input required")
-			taskInputRequired = true
-			currentTaskID = statusUpdate.TaskID
-			currentContextID = statusUpdate.ContextID
-			if statusUpdate.Status.Message != nil {
-				inputRequiredMessage = extractMessageText(statusUpdate.Status.Message)
+			case types.TaskStateCancelled:
+				logger.Info("task canceled")
+				fmt.Print("\n🚫 Task canceled")
+				return nil
+
+			default:
+				logger.Debug("unknown state", zap.String("state", string(statusUpdate.Status.State)))
 			}
-
-		case types.TaskStateFailed:
-			logger.Error("task failed")
-			fmt.Print("\n❌ Task failed")
-			return nil
-
-		case types.TaskStateCancelled:
-			logger.Info("task canceled")
-			fmt.Print("\n🚫 Task canceled")
-			return nil
-
-		default:
-			logger.Debug("unknown state", zap.String("state", string(statusUpdate.Status.State)))
 		}
 	}
 
@@ -248,42 +242,36 @@ func demonstrateStreamingInputRequiredFlow(a2aClient client.A2AClient, initialMe
 
 			resultBytes, _ := json.Marshal(event.Result)
 
-			// Try to parse as Task (for delta events)
+			// Check if this is a delta event (contains message parts to stream)
 			var task types.Task
-			if err := json.Unmarshal(resultBytes, &task); err == nil && task.Kind == "task" {
+			if err := json.Unmarshal(resultBytes, &task); err == nil && task.Status.Message != nil {
 				// Handle delta message - display text in real-time
-				if task.Status.Message != nil && len(task.Status.Message.Parts) > 0 {
+				if len(task.Status.Message.Parts) > 0 {
 					text := extractMessageText(task.Status.Message)
-					fmt.Print(text)
-					continuedText.WriteString(text)
+					if text != "" {
+						fmt.Print(text)
+						continuedText.WriteString(text)
+					}
 				}
-				continue
 			}
 
-			// Try to parse as TaskStatusUpdateEvent (for status changes)
+			// Check for status updates
 			var statusUpdate types.TaskStatusUpdateEvent
-			if err := json.Unmarshal(resultBytes, &statusUpdate); err != nil {
-				logger.Debug("failed to parse continued event", zap.Error(err))
-				continue
-			}
-
-			if statusUpdate.Kind != "status-update" {
-				continue
-			}
-
-			// Handle different task states
-			switch statusUpdate.Status.State {
-			case types.TaskStateCompleted:
-				logger.Info("continued task completed")
-				fmt.Printf("\n\n✅ Conversation complete!\n")
-				if continuedText.Len() > 0 {
-					fmt.Printf("\n📝 Final response:\n%s\n", continuedText.String())
+			if err := json.Unmarshal(resultBytes, &statusUpdate); err == nil && statusUpdate.TaskID != "" {
+				// Handle different task states
+				switch statusUpdate.Status.State {
+				case types.TaskStateCompleted:
+					logger.Info("continued task completed")
+					fmt.Printf("\n\n✅ Conversation complete!\n")
+					if continuedText.Len() > 0 {
+						fmt.Printf("\n📝 Final response:\n%s\n", continuedText.String())
+					}
+					return nil
+				case types.TaskStateFailed:
+					logger.Error("continued task failed")
+					fmt.Printf("\n❌ Task failed\n\n")
+					return nil
 				}
-				return nil
-			case types.TaskStateFailed:
-				logger.Error("continued task failed")
-				fmt.Printf("\n❌ Task failed\n\n")
-				return nil
 			}
 		}
 

--- a/examples/input-required/streaming/client/main.go
+++ b/examples/input-required/streaming/client/main.go
@@ -88,7 +88,7 @@ func demonstrateStreamingInputRequiredFlow(a2aClient client.A2AClient, initialMe
 		MessageID: fmt.Sprintf("msg-%d", time.Now().UnixNano()),
 		Role:      "user",
 		Parts: []types.Part{
-			types.NewTextPart(initialMessage),
+			types.CreateTextPart(initialMessage),
 		},
 	}
 
@@ -216,7 +216,7 @@ func demonstrateStreamingInputRequiredFlow(a2aClient client.A2AClient, initialMe
 			TaskID:    &currentTaskID,
 			ContextID: &currentContextID,
 			Parts: []types.Part{
-				types.NewTextPart(userResponse),
+				types.CreateTextPart(userResponse),
 			},
 		}
 
@@ -301,8 +301,8 @@ func demonstrateStreamingInputRequiredFlow(a2aClient client.A2AClient, initialMe
 // extractMessageText extracts text content from a message
 func extractMessageText(message *types.Message) string {
 	for _, part := range message.Parts {
-		if textPart, ok := part.(types.TextPart); ok {
-			return textPart.Text
+		if part.Text != nil {
+			return *part.Text
 		}
 	}
 	return ""

--- a/examples/input-required/streaming/client/main.go
+++ b/examples/input-required/streaming/client/main.go
@@ -174,7 +174,7 @@ func demonstrateStreamingInputRequiredFlow(a2aClient client.A2AClient, initialMe
 			fmt.Print("\n❌ Task failed")
 			return nil
 
-		case types.TaskStateCanceled:
+		case types.TaskStateCancelled:
 			logger.Info("task canceled")
 			fmt.Print("\n🚫 Task canceled")
 			return nil

--- a/examples/input-required/streaming/server/main.go
+++ b/examples/input-required/streaming/server/main.go
@@ -278,7 +278,6 @@ func (h *StreamingInputRequiredTaskHandler) sendStreamingStatus(outputChan chan<
 
 func (h *StreamingInputRequiredTaskHandler) sendInputRequiredEvent(outputChan chan<- cloudevents.Event, taskID, message string) {
 	inputMessage := &types.Message{
-		Kind:      "input_required",
 		MessageID: fmt.Sprintf("input-required-%s-%d", taskID, time.Now().UnixNano()),
 		Role:      "assistant",
 		Parts: []types.Part{

--- a/examples/input-required/streaming/server/main.go
+++ b/examples/input-required/streaming/server/main.go
@@ -235,7 +235,6 @@ func (h *StreamingInputRequiredTaskHandler) sendStreamingText(outputChan chan<- 
 		}
 
 		deltaMessage := &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("delta-%s-%d", taskID, time.Now().UnixNano()),
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -258,7 +257,6 @@ func (h *StreamingInputRequiredTaskHandler) sendStreamingText(outputChan chan<- 
 
 func (h *StreamingInputRequiredTaskHandler) sendStreamingStatus(outputChan chan<- cloudevents.Event, taskID, status string) {
 	statusMessage := &types.Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("status-%s-%d", taskID, time.Now().UnixNano()),
 		Role:      "assistant",
 		Parts: []types.Part{

--- a/examples/input-required/streaming/server/main.go
+++ b/examples/input-required/streaming/server/main.go
@@ -45,7 +45,7 @@ func (h *StreamingInputRequiredTaskHandler) GetAgent() server.OpenAICompatibleAg
 func (h *StreamingInputRequiredTaskHandler) HandleStreamingTask(ctx context.Context, task *types.Task, message *types.Message) (<-chan cloudevents.Event, error) {
 	h.logger.Info("processing streaming task with input-required demonstration",
 		zap.String("task_id", task.ID),
-		zap.String("message_role", message.Role))
+		zap.String("message_role", string(message.Role)))
 
 	outputChan := make(chan cloudevents.Event, 100)
 
@@ -144,12 +144,18 @@ func (h *StreamingInputRequiredTaskHandler) processWithoutAgentStreaming(ctx con
 	h.sendStreamingStatus(outputChan, task.ID, "Analyzing your request...")
 	time.Sleep(500 * time.Millisecond)
 
-	// Check if this is a follow-up to a previous input-required state
-	previousContext := getPreviousContext(task.History)
-	h.logger.Info("previous context", zap.String("context", previousContext))
+	// Check if task was previously in INPUT_REQUIRED state
+	// This means the current message is a follow-up providing the requested input
+	wasInputRequired := task.Status.State == types.TaskStateInputRequired
+	h.logger.Info("task state check",
+		zap.String("current_state", string(task.Status.State)),
+		zap.Bool("was_input_required", wasInputRequired))
 
-	// If this looks like a follow-up response (short message without keywords)
-	if previousContext != "" && !contains(messageText, "weather") && !contains(messageText, "calculate") && !contains(messageText, "hello") && len(messageText) < 50 {
+	// If we were waiting for input, check what was being asked
+	if wasInputRequired {
+		previousContext := getPreviousContext(task)
+		h.logger.Info("processing follow-up input", zap.String("context", previousContext))
+
 		switch previousContext {
 		case "weather":
 			// User provided location for weather query
@@ -236,12 +242,9 @@ func (h *StreamingInputRequiredTaskHandler) sendStreamingText(outputChan chan<- 
 
 		deltaMessage := &types.Message{
 			MessageID: fmt.Sprintf("delta-%s-%d", taskID, time.Now().UnixNano()),
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: chunk,
-				},
+				types.CreateTextPart(chunk),
 			},
 		}
 
@@ -258,14 +261,11 @@ func (h *StreamingInputRequiredTaskHandler) sendStreamingText(outputChan chan<- 
 func (h *StreamingInputRequiredTaskHandler) sendStreamingStatus(outputChan chan<- cloudevents.Event, taskID, status string) {
 	statusMessage := &types.Message{
 		MessageID: fmt.Sprintf("status-%s-%d", taskID, time.Now().UnixNano()),
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "data",
-				"data": map[string]any{
-					"status": status,
-				},
-			},
+			types.CreateDataPart(map[string]any{
+				"status": status,
+			}),
 		},
 	}
 
@@ -279,12 +279,9 @@ func (h *StreamingInputRequiredTaskHandler) sendStreamingStatus(outputChan chan<
 func (h *StreamingInputRequiredTaskHandler) sendInputRequiredEvent(outputChan chan<- cloudevents.Event, taskID, message string) {
 	inputMessage := &types.Message{
 		MessageID: fmt.Sprintf("input-required-%s-%d", taskID, time.Now().UnixNano()),
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: message,
-			},
+			types.CreateTextPart(message),
 		},
 	}
 
@@ -334,17 +331,8 @@ func (h *StreamingInputRequiredTaskHandler) sendErrorEvent(outputChan chan<- clo
 // Helper functions (same as non-streaming version)
 func getMessageText(message *types.Message) string {
 	for _, part := range message.Parts {
-		// Handle typed TextPart (when created locally)
-		if textPart, ok := part.(types.TextPart); ok {
-			return textPart.Text
-		}
-		// Handle map-based parts (when deserialized from JSON)
-		if partMap, ok := part.(map[string]any); ok {
-			if kind, exists := partMap["kind"]; exists && kind == "text" {
-				if text, exists := partMap["text"].(string); exists {
-					return text
-				}
-			}
+		if part.Text != nil {
+			return *part.Text
 		}
 	}
 	return ""
@@ -355,25 +343,26 @@ func contains(text, substr string) bool {
 		findInLower(toLower(text), toLower(substr)) >= 0
 }
 
-// getPreviousContext analyzes the conversation history to determine
+// getPreviousContext analyzes the task's status message to determine
 // what kind of input was previously requested
-func getPreviousContext(history []types.Message) string {
-	// Look backwards through history for input_required messages
-	for i := len(history) - 1; i >= 0; i-- {
-		msg := history[i]
-		if msg.Kind == "input_required" {
-			text := getMessageText(&msg)
-			textLower := toLower(text)
-
-			// Determine what was being asked about
-			if contains(textLower, "weather") || contains(textLower, "location") {
-				return "weather"
-			}
-			if contains(textLower, "calculat") || contains(textLower, "number") {
-				return "calculate"
-			}
-		}
+func getPreviousContext(task *types.Task) string {
+	// When a task is in INPUT_REQUIRED state, the Status.Message contains
+	// the prompt that was sent to the user asking for input
+	if task.Status.Message == nil {
+		return ""
 	}
+
+	text := getMessageText(task.Status.Message)
+	textLower := toLower(text)
+
+	// Determine what was being asked about based on the input request message
+	if contains(textLower, "weather") || contains(textLower, "location") {
+		return "weather"
+	}
+	if contains(textLower, "calculat") || contains(textLower, "number") {
+		return "calculate"
+	}
+
 	return ""
 }
 
@@ -477,7 +466,7 @@ Be specific about what information you need and why it's needed to provide a com
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -528,4 +517,9 @@ Be specific about what information you need and why it's needed to provide a com
 	}
 
 	logger.Info("server shutdown complete")
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/minimal/client/main.go
+++ b/examples/minimal/client/main.go
@@ -54,12 +54,9 @@ func main() {
 
 	// Create the message
 	message := types.Message{
-		Role: "user",
+		Role: types.RoleUser,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: "Hello, this is a test message. Please respond with a greeting.",
-			},
+			types.CreateTextPart("Hello, this is a test message. Please respond with a greeting."),
 		},
 	}
 

--- a/examples/minimal/server/main.go
+++ b/examples/minimal/server/main.go
@@ -49,7 +49,6 @@ func (h *SimpleTaskHandler) HandleTask(ctx context.Context, task *types.Task, me
 	}
 
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: uuid.New().String(),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,

--- a/examples/minimal/server/main.go
+++ b/examples/minimal/server/main.go
@@ -36,9 +36,8 @@ func (h *SimpleTaskHandler) HandleTask(ctx context.Context, task *types.Task, me
 	userInput := ""
 	if message != nil {
 		for _, part := range message.Parts {
-			switch p := part.(type) {
-			case types.TextPart:
-				userInput = p.Text
+			if part.Text != nil {
+				userInput = *part.Text
 			}
 		}
 	}
@@ -52,12 +51,9 @@ func (h *SimpleTaskHandler) HandleTask(ctx context.Context, task *types.Task, me
 		MessageID: uuid.New().String(),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: responseText,
-			},
+			types.CreateTextPart(responseText),
 		},
 	}
 
@@ -151,7 +147,7 @@ func main() {
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -193,4 +189,9 @@ func main() {
 	if err := a2aServer.Stop(shutdownCtx); err != nil {
 		logger.Error("shutdown error", zap.Error(err))
 	}
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/queue-storage/in-memory/client/main.go
+++ b/examples/queue-storage/in-memory/client/main.go
@@ -83,12 +83,9 @@ func main() {
 			ContextID: &contextID,
 			Kind:      "request",
 			MessageID: fmt.Sprintf("msg-%d", i+1),
-			Role:      "user",
+			Role:      types.RoleUser,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: taskContent,
-				},
+				types.CreateTextPart(taskContent),
 			},
 		}
 		params := types.MessageSendParams{
@@ -176,8 +173,8 @@ func main() {
 			// Extract text from the last message parts
 			var content string
 			for _, part := range lastMessage.Parts {
-				if textPart, ok := part.(types.TextPart); ok {
-					content = textPart.Text
+				if part.Text != nil {
+					content = *part.Text
 					break
 				}
 			}

--- a/examples/queue-storage/redis/client/main.go
+++ b/examples/queue-storage/redis/client/main.go
@@ -97,14 +97,10 @@ func main() {
 
 		message := types.Message{
 			ContextID: &contextID,
-			Kind:      "request",
 			MessageID: fmt.Sprintf("msg-%d", i+1),
-			Role:      "user",
+			Role:      types.RoleUser,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: taskContent,
-				},
+				types.CreateTextPart(taskContent),
 			},
 		}
 		params := types.MessageSendParams{
@@ -194,8 +190,8 @@ func main() {
 			// Extract text from the last message parts
 			var content string
 			for _, part := range lastMessage.Parts {
-				if textPart, ok := part.(types.TextPart); ok {
-					content = textPart.Text
+				if part.Text != nil {
+					content = *part.Text
 					break
 				}
 			}

--- a/examples/static-agent-card/server/main.go
+++ b/examples/static-agent-card/server/main.go
@@ -54,7 +54,6 @@ func (h *StaticCardTaskHandler) HandleTask(ctx context.Context, task *types.Task
 	}
 
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: uuid.New().String(),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,

--- a/examples/static-agent-card/server/main.go
+++ b/examples/static-agent-card/server/main.go
@@ -57,7 +57,7 @@ func (h *StaticCardTaskHandler) HandleTask(ctx context.Context, task *types.Task
 		MessageID: uuid.New().String(),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
 			types.CreateTextPart(responseText),
 		},

--- a/examples/static-agent-card/server/main.go
+++ b/examples/static-agent-card/server/main.go
@@ -36,8 +36,8 @@ func (h *StaticCardTaskHandler) HandleTask(ctx context.Context, task *types.Task
 	userInput := ""
 	if message != nil {
 		for _, part := range message.Parts {
-			if textPart, ok := part.(types.TextPart); ok {
-				userInput = textPart.Text
+			if part.Text != nil {
+				userInput = *part.Text
 				break
 			}
 		}
@@ -59,15 +59,12 @@ func (h *StaticCardTaskHandler) HandleTask(ctx context.Context, task *types.Task
 		TaskID:    &task.ID,
 		Role:      "assistant",
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: responseText,
-			},
+			types.CreateTextPart(responseText),
 		},
 	}
 
 	task.History = append(task.History, responseMessage)
-	task.Status.State = types.TaskStateCompleted
+	task.Status.State = string(types.TaskStateCompleted)
 	task.Status.Message = &responseMessage
 
 	return task, nil

--- a/examples/static-agent-card/server/main.go
+++ b/examples/static-agent-card/server/main.go
@@ -64,7 +64,7 @@ func (h *StaticCardTaskHandler) HandleTask(ctx context.Context, task *types.Task
 	}
 
 	task.History = append(task.History, responseMessage)
-	task.Status.State = string(types.TaskStateCompleted)
+	task.Status.State = types.TaskStateCompleted
 	task.Status.Message = &responseMessage
 
 	return task, nil

--- a/examples/streaming/client/main.go
+++ b/examples/streaming/client/main.go
@@ -127,7 +127,7 @@ func main() {
 			case types.TaskStateFailed:
 				logger.Error("task failed", zap.Int("event", eventCount))
 
-			case types.TaskStateCanceled:
+			case types.TaskStateCancelled:
 				logger.Info("task canceled", zap.Int("event", eventCount))
 			}
 			continue

--- a/examples/streaming/client/main.go
+++ b/examples/streaming/client/main.go
@@ -57,12 +57,9 @@ func main() {
 
 	// Create message with proper structure for streaming
 	message := types.Message{
-		Role: "user",
+		Role: types.RoleUser,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: "Please write a detailed explanation about machine learning. Stream your response as you generate it.",
-			},
+			types.CreateTextPart("Please write a detailed explanation about machine learning. Stream your response as you generate it."),
 		},
 	}
 
@@ -75,7 +72,11 @@ func main() {
 		},
 	}
 
-	logger.Info("sending streaming request", zap.String("prompt", message.Parts[0].(types.TextPart).Text))
+	promptText := ""
+	if message.Parts[0].Text != nil {
+		promptText = *message.Parts[0].Text
+	}
+	logger.Info("sending streaming request", zap.String("prompt", promptText))
 
 	// Test streaming
 	eventChan, err := a2aClient.SendTaskStreaming(ctx, params)
@@ -104,9 +105,9 @@ func main() {
 			// Handle delta message
 			if task.Status.Message != nil && len(task.Status.Message.Parts) > 0 {
 				for _, part := range task.Status.Message.Parts {
-					if textPart, ok := part.(types.TextPart); ok {
-						fmt.Print(textPart.Text)
-						finalResponse += textPart.Text
+					if part.Text != nil {
+						fmt.Print(*part.Text)
+						finalResponse += *part.Text
 					}
 				}
 			}

--- a/examples/streaming/server/main.go
+++ b/examples/streaming/server/main.go
@@ -77,12 +77,9 @@ func (m *MockAgent) RunWithStream(ctx context.Context, messages []types.Message)
 
 				// Create a delta message with just the new token
 				deltaMessage := types.Message{
-					Role: "assistant",
+					Role: types.RoleAgent,
 					Parts: []types.Part{
-						types.TextPart{
-							Kind: "text",
-							Text: delta,
-						},
+						types.CreateTextPart(delta),
 					},
 				}
 
@@ -100,14 +97,11 @@ func (m *MockAgent) RunWithStream(ctx context.Context, messages []types.Message)
 		m.logger.Debug("sending task completion event")
 		finalMessage := types.Message{
 			MessageID: fmt.Sprintf("mock-completion-%d", time.Now().UnixNano()),
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			TaskID:    &taskID,
 			ContextID: &contextID,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: fullText,
-				},
+				types.CreateTextPart(fullText),
 			},
 		}
 
@@ -142,8 +136,8 @@ func (h *MockTaskHandler) HandleTask(ctx context.Context, task *types.Task, mess
 	userInput := "Hello!"
 	if message != nil {
 		for _, part := range message.Parts {
-			if textPart, ok := part.(types.TextPart); ok {
-				userInput = textPart.Text
+			if part.Text != nil {
+				userInput = *part.Text
 				break
 			}
 		}
@@ -154,14 +148,11 @@ func (h *MockTaskHandler) HandleTask(ctx context.Context, task *types.Task, mess
 
 	responseMessage := types.Message{
 		MessageID: fmt.Sprintf("mock-response-%s", task.ID),
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		TaskID:    &task.ID,
 		ContextID: &task.ContextID,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: response,
-			},
+			types.CreateTextPart(response),
 		},
 	}
 
@@ -264,7 +255,7 @@ func main() {
 			Name:            server.BuildAgentName,
 			Description:     server.BuildAgentDescription,
 			Version:         server.BuildAgentVersion,
-			URL:             fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("http://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "3.0.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -306,4 +297,9 @@ func main() {
 	if err := a2aServer.Stop(shutdownCtx); err != nil {
 		logger.Error("shutdown error", zap.Error(err))
 	}
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/streaming/server/main.go
+++ b/examples/streaming/server/main.go
@@ -99,7 +99,6 @@ func (m *MockAgent) RunWithStream(ctx context.Context, messages []types.Message)
 		// Send task completion event with final message
 		m.logger.Debug("sending task completion event")
 		finalMessage := types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("mock-completion-%d", time.Now().UnixNano()),
 			Role:      "assistant",
 			TaskID:    &taskID,
@@ -154,7 +153,6 @@ func (h *MockTaskHandler) HandleTask(ctx context.Context, task *types.Task, mess
 	response := fmt.Sprintf("Mock response: I received your message '%s'. This is a mock response since no AI provider is configured.", userInput)
 
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("mock-response-%s", task.ID),
 		Role:      "assistant",
 		TaskID:    &task.ID,

--- a/examples/tls-server/client/main.go
+++ b/examples/tls-server/client/main.go
@@ -130,12 +130,9 @@ func main() {
 
 		// Create task message
 		taskMessage := types.Message{
-			Role: "user",
+			Role: types.RoleUser,
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: message,
-				},
+				types.CreateTextPart(message),
 			},
 		}
 

--- a/examples/tls-server/server/main.go
+++ b/examples/tls-server/server/main.go
@@ -35,8 +35,8 @@ func (h *SimpleTaskHandler) HandleTask(ctx context.Context, task *types.Task, me
 	userInput := ""
 	if message != nil {
 		for _, part := range message.Parts {
-			if textPart, ok := part.(types.TextPart); ok {
-				userInput = textPart.Text
+			if part.Text != nil {
+				userInput = *part.Text
 				break
 			}
 		}
@@ -53,12 +53,9 @@ func (h *SimpleTaskHandler) HandleTask(ctx context.Context, task *types.Task, me
 		MessageID: fmt.Sprintf("msg-%s", task.ID),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: responseText,
-			},
+			types.CreateTextPart(responseText),
 		},
 	}
 
@@ -187,7 +184,7 @@ func main() {
 			Name:            cfg.A2A.AgentName,
 			Description:     cfg.A2A.AgentDescription,
 			Version:         cfg.A2A.AgentVersion,
-			URL:             fmt.Sprintf("https://localhost:%s", cfg.A2A.ServerConfig.Port),
+			URL:             stringPtr(fmt.Sprintf("https://localhost:%s", cfg.A2A.ServerConfig.Port)),
 			ProtocolVersion: "0.3.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              &cfg.A2A.CapabilitiesConfig.Streaming,
@@ -229,4 +226,9 @@ func main() {
 	if err := a2aServer.Stop(shutdownCtx); err != nil {
 		logger.Error("shutdown error", zap.Error(err))
 	}
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
 }

--- a/examples/tls-server/server/main.go
+++ b/examples/tls-server/server/main.go
@@ -50,7 +50,6 @@ func (h *SimpleTaskHandler) HandleTask(ctx context.Context, task *types.Task, me
 
 	// Create response message
 	responseMessage := types.Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("msg-%s", task.ID),
 		ContextID: &task.ContextID,
 		TaskID:    &task.ID,

--- a/schema.yaml
+++ b/schema.yaml
@@ -1,59 +1,27 @@
 $schema: http://json-schema.org/draft-07/schema#
 definitions:
-  A2AError:
-    anyOf:
-      - $ref: '#/definitions/JSONParseError'
-      - $ref: '#/definitions/InvalidRequestError'
-      - $ref: '#/definitions/MethodNotFoundError'
-      - $ref: '#/definitions/InvalidParamsError'
-      - $ref: '#/definitions/InternalError'
-      - $ref: '#/definitions/TaskNotFoundError'
-      - $ref: '#/definitions/TaskNotCancelableError'
-      - $ref: '#/definitions/PushNotificationNotSupportedError'
-      - $ref: '#/definitions/UnsupportedOperationError'
-      - $ref: '#/definitions/ContentTypeNotSupportedError'
-      - $ref: '#/definitions/InvalidAgentResponseError'
-      - $ref: '#/definitions/AuthenticatedExtendedCardNotConfiguredError'
-    description: A discriminated union of all standard JSON-RPC and A2A-specific error types.
-  A2ARequest:
-    anyOf:
-      - $ref: '#/definitions/SendMessageRequest'
-      - $ref: '#/definitions/SendStreamingMessageRequest'
-      - $ref: '#/definitions/GetTaskRequest'
-      - $ref: '#/definitions/CancelTaskRequest'
-      - $ref: '#/definitions/SetTaskPushNotificationConfigRequest'
-      - $ref: '#/definitions/GetTaskPushNotificationConfigRequest'
-      - $ref: '#/definitions/TaskResubscriptionRequest'
-      - $ref: '#/definitions/ListTaskPushNotificationConfigRequest'
-      - $ref: '#/definitions/DeleteTaskPushNotificationConfigRequest'
-      - $ref: '#/definitions/GetAuthenticatedExtendedCardRequest'
-    description: A discriminated union representing all possible JSON-RPC 2.0 requests supported by the A2A specification.
   APIKeySecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using an API key.
     properties:
       description:
         description: An optional description for the security scheme.
         type: string
-      in:
-        description: The location of the API key.
-        enum:
-          - cookie
-          - header
-          - query
+      location:
+        description: The location of the API key. Valid values are "query", "header", or "cookie".
         type: string
       name:
         description: The name of the header, query, or cookie parameter to be used.
         type: string
-      type:
-        const: apiKey
-        description: The type of the security scheme. Must be 'apiKey'.
-        type: string
     required:
-      - in
+      - location
       - name
-      - type
+    title: API Key Security Scheme
     type: object
   AgentCapabilities:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines optional capabilities supported by an agent.
     properties:
       extensions:
@@ -68,112 +36,108 @@ definitions:
         description: Indicates if the agent provides a history of state transitions for a task.
         type: boolean
       streaming:
-        description: Indicates if the agent supports Server-Sent Events (SSE) for streaming responses.
+        description: Indicates if the agent supports streaming responses.
         type: boolean
+    title: Agent Capabilities
+    type: object
+  AgentExtension:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: A declaration of a protocol extension supported by an Agent.
+    properties:
+      description:
+        description: A human-readable description of how this agent uses the extension.
+        type: string
+      params:
+        $ref: '#/definitions/Struct'
+        description: Optional, extension-specific configuration parameters.
+      required:
+        description: If true, the client must understand and comply with the extension's requirements.
+        type: boolean
+      uri:
+        description: The unique URI identifying the extension.
+        type: string
+    required:
+      - uri
+      - description
+      - required
+    title: Agent Extension
+    type: object
+  Struct:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    title: Struct
     type: object
   AgentCard:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
-      The AgentCard is a self-describing manifest for an agent. It provides essential
-      metadata including the agent's identity, capabilities, skills, supported
-      communication methods, and security requirements.
+      AgentCard is a self-describing manifest for an agent. It provides essential
+       metadata including the agent's identity, capabilities, skills, supported
+       communication methods, and security requirements.
+       Next ID: 20
     properties:
       additionalInterfaces:
-        description: |-
-          A list of additional supported interfaces (transport and URL combinations).
-          This allows agents to expose multiple transports, potentially at different URLs.
-
-          Best practices:
-          - SHOULD include all supported transports for completeness
-          - SHOULD include an entry matching the main 'url' and 'preferredTransport'
-          - MAY reuse URLs if multiple transports are available at the same endpoint
-          - MUST accurately declare the transport available at each URL
-
-          Clients can select any interface from this list based on their transport capabilities
-          and preferences. This enables transport negotiation and fallback scenarios.
+        description: 'DEPRECATED: Use ''supported_interfaces'' instead.'
         items:
           $ref: '#/definitions/AgentInterface'
         type: array
       capabilities:
         $ref: '#/definitions/AgentCapabilities'
-        description: A declaration of optional capabilities supported by the agent.
+        description: A2A Capability set supported by the agent.
       defaultInputModes:
         description: |-
-          Default set of supported input MIME types for all skills, which can be
-          overridden on a per-skill basis.
+          protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
+           The set of interaction modes that the agent supports across all skills.
+           This can be overridden per skill. Defined as media types.
         items:
           type: string
         type: array
       defaultOutputModes:
-        description: |-
-          Default set of supported output MIME types for all skills, which can be
-          overridden on a per-skill basis.
+        description: The media types supported as outputs from this agent.
         items:
           type: string
         type: array
       description:
         description: |-
           A human-readable description of the agent, assisting users and other agents
-          in understanding its purpose.
-        examples:
-          - Agent that helps users with recipes and cooking.
+           in understanding its purpose.
+           Example: "Agent that helps users with recipes and cooking."
         type: string
       documentationUrl:
-        description: An optional URL to the agent's documentation.
+        description: A url to provide additional documentation about the agent.
         type: string
       iconUrl:
         description: An optional URL to an icon for the agent.
         type: string
       name:
-        description: A human-readable name for the agent.
-        examples:
-          - Recipe Agent
+        description: |-
+          A human readable name for the agent.
+           Example: "Recipe Agent"
         type: string
       preferredTransport:
-        default: JSONRPC
-        description: |-
-          The transport protocol for the preferred endpoint (the main 'url' field).
-          If not specified, defaults to 'JSONRPC'.
-
-          IMPORTANT: The transport specified here MUST be available at the main 'url'.
-          This creates a binding between the main URL and its supported transport protocol.
-          Clients should prefer this transport and URL combination when both are supported.
-        examples:
-          - JSONRPC
-          - GRPC
-          - HTTP+JSON
+        description: 'DEPRECATED: Use ''supported_interfaces'' instead.'
         type: string
       protocolVersion:
-        default: 0.3.0
-        description: The version of the A2A protocol this agent supports.
+        description: |-
+          The version of the A2A protocol this agent supports.
+           Default: "1.0"
         type: string
       provider:
         $ref: '#/definitions/AgentProvider'
-        description: Information about the agent's service provider.
+        description: The service provider of the agent.
       security:
         description: |-
-          A list of security requirement objects that apply to all agent interactions. Each object
-          lists security schemes that can be used. Follows the OpenAPI 3.0 Security Requirement Object.
-          This list can be seen as an OR of ANDs. Each object in the list describes one possible
-          set of security requirements that must be present on a request. This allows specifying,
-          for example, "callers must either use OAuth OR an API Key AND mTLS."
-        examples:
-          - - oauth:
-                - read
-            - api-key: []
-              mtls: []
+          protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+           Security requirements for contacting the agent.
         items:
-          additionalProperties:
-            items:
-              type: string
-            type: array
-          type: object
+          $ref: '#/definitions/Security'
         type: array
       securitySchemes:
         additionalProperties:
           $ref: '#/definitions/SecurityScheme'
-        description: |-
-          A declaration of the security schemes available to authorize requests. The key is the
-          scheme name. Follows the OpenAPI 3.0 Security Scheme Object.
+        description: The security scheme details used for authenticating with this agent.
+        propertyNames:
+          type: string
         type: object
       signatures:
         description: JSON Web Signatures computed for this AgentCard.
@@ -181,137 +145,119 @@ definitions:
           $ref: '#/definitions/AgentCardSignature'
         type: array
       skills:
-        description: The set of skills, or distinct capabilities, that the agent can perform.
+        description: |-
+          Skills represent an ability of an agent. It is largely
+           a descriptive concept but represents a more focused set of behaviors that the
+           agent is likely to succeed at.
         items:
           $ref: '#/definitions/AgentSkill'
         type: array
-      supportsAuthenticatedExtendedCard:
-        description: |-
-          If true, the agent can provide an extended agent card with additional details
-          to authenticated users. Defaults to false.
+      supportedInterfaces:
+        description: Ordered list of supported interfaces. First entry is preferred.
+        items:
+          $ref: '#/definitions/AgentInterface'
+        type: array
+      supportsExtendedAgentCard:
+        description: Whether the agent supports providing an extended agent card when authenticated.
         type: boolean
       url:
-        description: |-
-          The preferred endpoint URL for interacting with the agent.
-          This URL MUST support the transport specified by 'preferredTransport'.
-        examples:
-          - https://api.example.com/a2a/v1
+        description: 'DEPRECATED: Use ''supported_interfaces'' instead.'
         type: string
       version:
-        description: The agent's own version number. The format is defined by the provider.
-        examples:
-          - 1.0.0
+        description: |-
+          The version of the agent.
+           Example: "1.0.0"
         type: string
     required:
+      - protocolVersion
+      - name
+      - description
+      - version
       - capabilities
       - defaultInputModes
       - defaultOutputModes
-      - description
-      - name
-      - protocolVersion
       - skills
-      - url
-      - version
+    title: Agent Card
     type: object
   AgentCardSignature:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
       AgentCardSignature represents a JWS signature of an AgentCard.
-      This follows the JSON format of an RFC 7515 JSON Web Signature (JWS).
+       This follows the JSON format of an RFC 7515 JSON Web Signature (JWS).
     properties:
       header:
-        additionalProperties: {}
+        $ref: '#/definitions/Struct'
         description: The unprotected JWS header values.
-        type: object
       protected:
         description: |-
-          The protected JWS header for the signature. This is a Base64url-encoded
-          JSON object, as per RFC 7515.
+          The protected JWS header for the signature. This is always a
+           base64url-encoded JSON object. Required.
         type: string
       signature:
-        description: The computed signature, Base64url-encoded.
+        description: The computed signature, base64url-encoded. Required.
         type: string
     required:
       - protected
       - signature
-    type: object
-  AgentExtension:
-    description: A declaration of a protocol extension supported by an Agent.
-    examples:
-      - description: Google OAuth 2.0 authentication
-        required: false
-        uri: https://developers.google.com/identity/protocols/oauth2
-    properties:
-      description:
-        description: A human-readable description of how this agent uses the extension.
-        type: string
-      params:
-        additionalProperties: {}
-        description: Optional, extension-specific configuration parameters.
-        type: object
-      required:
-        description: |-
-          If true, the client must understand and comply with the extension's requirements
-          to interact with the agent.
-        type: boolean
-      uri:
-        description: The unique URI identifying the extension.
-        type: string
-    required:
-      - uri
+    title: Agent Card Signature
     type: object
   AgentInterface:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
       Declares a combination of a target URL and a transport protocol for interacting with the agent.
-      This allows agents to expose the same functionality over multiple transport mechanisms.
+       This allows agents to expose the same functionality over multiple protocol binding mechanisms.
     properties:
-      transport:
-        description: The transport protocol supported at this URL.
-        examples:
-          - JSONRPC
-          - GRPC
-          - HTTP+JSON
+      protocolBinding:
+        description: |-
+          The protocol binding supported at this URL. This is an open form string, to be
+           easily extended for other protocol bindings. The core ones officially
+           supported are `JSONRPC`, `GRPC` and `HTTP+JSON`.
+        type: string
+      tenant:
+        description: Tenant to be set in the request when calling the agent.
         type: string
       url:
-        description: The URL where this interface is available. Must be a valid absolute HTTPS URL in production.
-        examples:
-          - https://api.example.com/a2a/v1
-          - https://grpc.example.com/a2a
-          - https://rest.example.com/v1
+        description: |-
+          The URL where this interface is available. Must be a valid absolute HTTPS URL in production.
+           Example: "https://api.example.com/a2a/v1", "https://grpc.example.com/a2a"
         type: string
     required:
-      - transport
       - url
+      - protocolBinding
+    title: Agent Interface
     type: object
   AgentProvider:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Represents the service provider of an agent.
-    examples:
-      - organization: Google
-        url: https://ai.google.dev
     properties:
       organization:
-        description: The name of the agent provider's organization.
+        description: |-
+          The name of the agent provider's organization.
+           Example: "Google"
         type: string
       url:
-        description: A URL for the agent provider's website or relevant documentation.
+        description: |-
+          A URL for the agent provider's website or relevant documentation.
+           Example: "https://ai.google.dev"
         type: string
     required:
-      - organization
       - url
+      - organization
+    title: Agent Provider
     type: object
   AgentSkill:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Represents a distinct capability or function that an agent can perform.
     properties:
       description:
-        description: |-
-          A detailed description of the skill, intended to help clients or users
-          understand its purpose and functionality.
+        description: A detailed description of the skill.
         type: string
       examples:
-        description: |-
-          Example prompts or scenarios that this skill can handle. Provides a hint to
-          the client on how to use the skill.
-        examples:
-          - - I need a recipe for bread
+        description: Example prompts or scenarios that this skill can handle.
         items:
           type: string
         type: array
@@ -319,7 +265,7 @@ definitions:
         description: A unique identifier for the agent's skill.
         type: string
       inputModes:
-        description: The set of supported input MIME types for this skill, overriding the agent's defaults.
+        description: The set of supported input media types for this skill, overriding the agent's defaults.
         items:
           type: string
         type: array
@@ -327,535 +273,88 @@ definitions:
         description: A human-readable name for the skill.
         type: string
       outputModes:
-        description: The set of supported output MIME types for this skill, overriding the agent's defaults.
+        description: The set of supported output media types for this skill, overriding the agent's defaults.
         items:
           type: string
         type: array
       security:
         description: |-
-          Security schemes necessary for the agent to leverage this skill.
-          As in the overall AgentCard.security, this list represents a logical OR of security
-          requirement objects. Each object is a set of security schemes that must be used together
-          (a logical AND).
-        examples:
-          - - google:
-                - oidc
+          protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+           Security schemes necessary for this skill.
         items:
-          additionalProperties:
-            items:
-              type: string
-            type: array
-          type: object
+          $ref: '#/definitions/Security'
         type: array
       tags:
         description: A set of keywords describing the skill's capabilities.
-        examples:
-          - - cooking
-            - customer support
-            - billing
         items:
           type: string
         type: array
     required:
-      - description
       - id
       - name
+      - description
       - tags
-    type: object
-  Artifact:
-    description: Represents a file, data structure, or other resource generated by an agent during a task.
-    properties:
-      artifactId:
-        description: A unique identifier (e.g. UUID) for the artifact within the scope of the task.
-        type: string
-      description:
-        description: An optional, human-readable description of the artifact.
-        type: string
-      extensions:
-        description: The URIs of extensions that are relevant to this artifact.
-        items:
-          type: string
-        type: array
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions. The key is an extension-specific identifier.
-        type: object
-      name:
-        description: An optional, human-readable name for the artifact.
-        type: string
-      parts:
-        description: An array of content parts that make up the artifact.
-        items:
-          $ref: '#/definitions/Part'
-        type: array
-    required:
-      - artifactId
-      - parts
-    type: object
-  AuthenticatedExtendedCardNotConfiguredError:
-    description: An A2A-specific error indicating that the agent does not have an Authenticated Extended Card configured
-    properties:
-      code:
-        const: -32007
-        description: The error code for when an authenticated extended card is not configured.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Authenticated Extended Card is not configured
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
+    title: Agent Skill
     type: object
   AuthorizationCodeOAuthFlow:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines configuration details for the OAuth 2.0 Authorization Code flow.
     properties:
       authorizationUrl:
-        description: |-
-          The authorization URL to be used for this flow.
-          This MUST be a URL and use TLS.
+        description: The authorization URL to be used for this flow.
         type: string
       refreshUrl:
-        description: |-
-          The URL to be used for obtaining refresh tokens.
-          This MUST be a URL and use TLS.
+        description: The URL to be used for obtaining refresh tokens.
         type: string
       scopes:
         additionalProperties:
           type: string
-        description: |-
-          The available scopes for the OAuth2 security scheme. A map between the scope
-          name and a short description for it.
+        description: The available scopes for the OAuth2 security scheme.
+        propertyNames:
+          type: string
         type: object
       tokenUrl:
-        description: |-
-          The token URL to be used for this flow.
-          This MUST be a URL and use TLS.
+        description: The token URL to be used for this flow.
         type: string
     required:
       - authorizationUrl
-      - scopes
       - tokenUrl
-    type: object
-  CancelTaskRequest:
-    description: Represents a JSON-RPC request for the `tasks/cancel` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/cancel
-        description: The method name. Must be 'tasks/cancel'.
-        type: string
-      params:
-        $ref: '#/definitions/TaskIdParams'
-        description: The parameters identifying the task to cancel.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  CancelTaskResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/CancelTaskSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/cancel` method.
-  CancelTaskSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/cancel` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/Task'
-        description: The result, containing the final state of the canceled Task object.
-    required:
-      - id
-      - jsonrpc
-      - result
+      - scopes
+    title: Authorization CodeO Auth Flow
     type: object
   ClientCredentialsOAuthFlow:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines configuration details for the OAuth 2.0 Client Credentials flow.
     properties:
       refreshUrl:
-        description: The URL to be used for obtaining refresh tokens. This MUST be a URL.
+        description: The URL to be used for obtaining refresh tokens.
         type: string
       scopes:
         additionalProperties:
           type: string
-        description: |-
-          The available scopes for the OAuth2 security scheme. A map between the scope
-          name and a short description for it.
+        description: The available scopes for the OAuth2 security scheme.
+        propertyNames:
+          type: string
         type: object
       tokenUrl:
-        description: The token URL to be used for this flow. This MUST be a URL.
+        description: The token URL to be used for this flow.
         type: string
     required:
-      - scopes
       - tokenUrl
-    type: object
-  ContentTypeNotSupportedError:
-    description: |-
-      An A2A-specific error indicating an incompatibility between the requested
-      content types and the agent's capabilities.
-    properties:
-      code:
-        const: -32005
-        description: The error code for an unsupported content type.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Incompatible content types
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  DataPart:
-    description: Represents a structured data segment (e.g., JSON) within a message or artifact.
-    properties:
-      data:
-        additionalProperties: {}
-        description: The structured data content.
-        type: object
-      kind:
-        const: data
-        description: The type of this part, used as a discriminator. Always 'data'.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with this part.
-        type: object
-    required:
-      - data
-      - kind
-    type: object
-  DeleteTaskPushNotificationConfigParams:
-    description: Defines parameters for deleting a specific push notification configuration for a task.
-    properties:
-      id:
-        description: The unique identifier (e.g. UUID) of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-      pushNotificationConfigId:
-        description: The ID of the push notification configuration to delete.
-        type: string
-    required:
-      - id
-      - pushNotificationConfigId
-    type: object
-  DeleteTaskPushNotificationConfigRequest:
-    description: Represents a JSON-RPC request for the `tasks/pushNotificationConfig/delete` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/pushNotificationConfig/delete
-        description: The method name. Must be 'tasks/pushNotificationConfig/delete'.
-        type: string
-      params:
-        $ref: '#/definitions/DeleteTaskPushNotificationConfigParams'
-        description: The parameters identifying the push notification configuration to delete.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  DeleteTaskPushNotificationConfigResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/DeleteTaskPushNotificationConfigSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.
-  DeleteTaskPushNotificationConfigSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        description: The result is null on successful deletion.
-        type: 'null'
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  FileBase:
-    description: Defines base properties for a file.
-    properties:
-      mimeType:
-        description: The MIME type of the file (e.g., "application/pdf").
-        type: string
-      name:
-        description: An optional name for the file (e.g., "document.pdf").
-        type: string
-    type: object
-  FilePart:
-    description: |-
-      Represents a file segment within a message or artifact. The file content can be
-      provided either directly as bytes or as a URI.
-    properties:
-      file:
-        anyOf:
-          - $ref: '#/definitions/FileWithBytes'
-          - $ref: '#/definitions/FileWithUri'
-        description: The file content, represented as either a URI or as base64-encoded bytes.
-      kind:
-        const: file
-        description: The type of this part, used as a discriminator. Always 'file'.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with this part.
-        type: object
-    required:
-      - file
-      - kind
-    type: object
-  FileWithBytes:
-    description: Represents a file with its content provided directly as a base64-encoded string.
-    properties:
-      bytes:
-        description: The base64-encoded content of the file.
-        type: string
-      mimeType:
-        description: The MIME type of the file (e.g., "application/pdf").
-        type: string
-      name:
-        description: An optional name for the file (e.g., "document.pdf").
-        type: string
-    required:
-      - bytes
-    type: object
-  FileWithUri:
-    description: Represents a file with its content located at a specific URI.
-    properties:
-      mimeType:
-        description: The MIME type of the file (e.g., "application/pdf").
-        type: string
-      name:
-        description: An optional name for the file (e.g., "document.pdf").
-        type: string
-      uri:
-        description: A URL pointing to the file's content.
-        type: string
-    required:
-      - uri
-    type: object
-  GetAuthenticatedExtendedCardRequest:
-    description: Represents a JSON-RPC request for the `agent/getAuthenticatedExtendedCard` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: agent/getAuthenticatedExtendedCard
-        description: The method name. Must be 'agent/getAuthenticatedExtendedCard'.
-        type: string
-    required:
-      - id
-      - jsonrpc
-      - method
-    type: object
-  GetAuthenticatedExtendedCardResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/GetAuthenticatedExtendedCardSuccessResponse'
-    description: Represents a JSON-RPC response for the `agent/getAuthenticatedExtendedCard` method.
-  GetAuthenticatedExtendedCardSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `agent/getAuthenticatedExtendedCard` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/AgentCard'
-        description: The result is an Agent Card object.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  GetTaskPushNotificationConfigParams:
-    description: Defines parameters for fetching a specific push notification configuration for a task.
-    properties:
-      id:
-        description: The unique identifier (e.g. UUID) of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-      pushNotificationConfigId:
-        description: The ID of the push notification configuration to retrieve.
-        type: string
-    required:
-      - id
-    type: object
-  GetTaskPushNotificationConfigRequest:
-    description: Represents a JSON-RPC request for the `tasks/pushNotificationConfig/get` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/pushNotificationConfig/get
-        description: The method name. Must be 'tasks/pushNotificationConfig/get'.
-        type: string
-      params:
-        anyOf:
-          - $ref: '#/definitions/TaskIdParams'
-          - $ref: '#/definitions/GetTaskPushNotificationConfigParams'
-        description: The parameters for getting a push notification configuration.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  GetTaskPushNotificationConfigResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/GetTaskPushNotificationConfigSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/pushNotificationConfig/get` method.
-  GetTaskPushNotificationConfigSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/get` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/TaskPushNotificationConfig'
-        description: The result, containing the requested push notification configuration.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  GetTaskRequest:
-    description: Represents a JSON-RPC request for the `tasks/get` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/get
-        description: The method name. Must be 'tasks/get'.
-        type: string
-      params:
-        $ref: '#/definitions/TaskQueryParams'
-        description: The parameters for querying a task.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  GetTaskResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/GetTaskSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/get` method.
-  GetTaskSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/get` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/Task'
-        description: The result, containing the requested Task object.
-    required:
-      - id
-      - jsonrpc
-      - result
+      - scopes
+    title: Client CredentialsO Auth Flow
     type: object
   HTTPAuthSecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using HTTP authentication.
     properties:
       bearerFormat:
         description: |-
           A hint to the client to identify how the bearer token is formatted (e.g., "JWT").
-          This is primarily for documentation purposes.
+           This is primarily for documentation purposes.
         type: string
       description:
         description: An optional description for the security scheme.
@@ -863,448 +362,51 @@ definitions:
       scheme:
         description: |-
           The name of the HTTP Authentication scheme to be used in the Authorization header,
-          as defined in RFC7235 (e.g., "Bearer").
-          This value should be registered in the IANA Authentication Scheme registry.
-        type: string
-      type:
-        const: http
-        description: The type of the security scheme. Must be 'http'.
+           as defined in RFC7235 (e.g., "Bearer").
+           This value should be registered in the IANA Authentication Scheme registry.
         type: string
     required:
       - scheme
-      - type
+    title: HTTP Auth Security Scheme
     type: object
   ImplicitOAuthFlow:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines configuration details for the OAuth 2.0 Implicit flow.
     properties:
       authorizationUrl:
-        description: The authorization URL to be used for this flow. This MUST be a URL.
+        description: The authorization URL to be used for this flow.
         type: string
       refreshUrl:
-        description: The URL to be used for obtaining refresh tokens. This MUST be a URL.
+        description: The URL to be used for obtaining refresh tokens.
         type: string
       scopes:
         additionalProperties:
           type: string
-        description: |-
-          The available scopes for the OAuth2 security scheme. A map between the scope
-          name and a short description for it.
+        description: The available scopes for the OAuth2 security scheme.
+        propertyNames:
+          type: string
         type: object
     required:
       - authorizationUrl
       - scopes
+    title: ImplicitO Auth Flow
     type: object
-  InternalError:
-    description: An error indicating an internal error on the server.
-    properties:
-      code:
-        const: -32603
-        description: The error code for an internal server error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Internal error
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  InvalidAgentResponseError:
-    description: |-
-      An A2A-specific error indicating that the agent returned a response that
-      does not conform to the specification for the current method.
-    properties:
-      code:
-        const: -32006
-        description: The error code for an invalid agent response.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Invalid agent response
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  InvalidParamsError:
-    description: An error indicating that the method parameters are invalid.
-    properties:
-      code:
-        const: -32602
-        description: The error code for an invalid parameters error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Invalid parameters
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  InvalidRequestError:
-    description: An error indicating that the JSON sent is not a valid Request object.
-    properties:
-      code:
-        const: -32600
-        description: The error code for an invalid request.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Request payload validation error
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  JSONParseError:
-    description: An error indicating that the server received invalid JSON.
-    properties:
-      code:
-        const: -32700
-        description: The error code for a JSON parse error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Invalid JSON payload
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  JSONRPCError:
-    description: Represents a JSON-RPC 2.0 Error object, included in an error response.
-    properties:
-      code:
-        description: A number that indicates the error type that occurred.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        description: A string providing a short description of the error.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  JSONRPCErrorResponse:
-    description: Represents a JSON-RPC 2.0 Error Response object.
-    properties:
-      error:
-        anyOf:
-          - $ref: '#/definitions/JSONRPCError'
-          - $ref: '#/definitions/JSONParseError'
-          - $ref: '#/definitions/InvalidRequestError'
-          - $ref: '#/definitions/MethodNotFoundError'
-          - $ref: '#/definitions/InvalidParamsError'
-          - $ref: '#/definitions/InternalError'
-          - $ref: '#/definitions/TaskNotFoundError'
-          - $ref: '#/definitions/TaskNotCancelableError'
-          - $ref: '#/definitions/PushNotificationNotSupportedError'
-          - $ref: '#/definitions/UnsupportedOperationError'
-          - $ref: '#/definitions/ContentTypeNotSupportedError'
-          - $ref: '#/definitions/InvalidAgentResponseError'
-          - $ref: '#/definitions/AuthenticatedExtendedCardNotConfiguredError'
-        description: An object describing the error that occurred.
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-    required:
-      - error
-      - id
-      - jsonrpc
-    type: object
-  JSONRPCMessage:
-    description: Defines the base structure for any JSON-RPC 2.0 request, response, or notification.
-    properties:
-      id:
-        description: |-
-          A unique identifier established by the client. It must be a String, a Number, or null.
-          The server must reply with the same value in the response. This property is omitted for notifications.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-    required:
-      - jsonrpc
-    type: object
-  JSONRPCRequest:
-    description: Represents a JSON-RPC 2.0 Request object.
-    properties:
-      id:
-        description: |-
-          A unique identifier established by the client. It must be a String, a Number, or null.
-          The server must reply with the same value in the response. This property is omitted for notifications.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        description: A string containing the name of the method to be invoked.
-        type: string
-      params:
-        additionalProperties: {}
-        description: A structured value holding the parameter values to be used during the method invocation.
-        type: object
-    required:
-      - jsonrpc
-      - method
-    type: object
-  JSONRPCResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/SendMessageSuccessResponse'
-      - $ref: '#/definitions/SendStreamingMessageSuccessResponse'
-      - $ref: '#/definitions/GetTaskSuccessResponse'
-      - $ref: '#/definitions/CancelTaskSuccessResponse'
-      - $ref: '#/definitions/SetTaskPushNotificationConfigSuccessResponse'
-      - $ref: '#/definitions/GetTaskPushNotificationConfigSuccessResponse'
-      - $ref: '#/definitions/ListTaskPushNotificationConfigSuccessResponse'
-      - $ref: '#/definitions/DeleteTaskPushNotificationConfigSuccessResponse'
-      - $ref: '#/definitions/GetAuthenticatedExtendedCardSuccessResponse'
-    description: |-
-      A discriminated union representing all possible JSON-RPC 2.0 responses
-      for the A2A specification methods.
-  JSONRPCSuccessResponse:
-    description: Represents a successful JSON-RPC 2.0 Response object.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        description: The value of this member is determined by the method invoked on the Server.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  ListTaskPushNotificationConfigParams:
-    description: Defines parameters for listing all push notification configurations associated with a task.
-    properties:
-      id:
-        description: The unique identifier (e.g. UUID) of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-    required:
-      - id
-    type: object
-  ListTaskPushNotificationConfigRequest:
-    description: Represents a JSON-RPC request for the `tasks/pushNotificationConfig/list` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/pushNotificationConfig/list
-        description: The method name. Must be 'tasks/pushNotificationConfig/list'.
-        type: string
-      params:
-        $ref: '#/definitions/ListTaskPushNotificationConfigParams'
-        description: The parameters identifying the task whose configurations are to be listed.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  ListTaskPushNotificationConfigResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/ListTaskPushNotificationConfigSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/pushNotificationConfig/list` method.
-  ListTaskPushNotificationConfigSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/list` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        description: The result, containing an array of all push notification configurations for the task.
-        items:
-          $ref: '#/definitions/TaskPushNotificationConfig'
-        type: array
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  Message:
-    description: Represents a single message in the conversation between a user and an agent.
-    properties:
-      contextId:
-        description: The context ID for this message, used to group related interactions.
-        type: string
-      extensions:
-        description: The URIs of extensions that are relevant to this message.
-        items:
-          type: string
-        type: array
-      kind:
-        const: message
-        description: The type of this object, used as a discriminator. Always 'message' for a Message.
-        type: string
-      messageId:
-        description: A unique identifier for the message, typically a UUID, generated by the sender.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions. The key is an extension-specific identifier.
-        type: object
-      parts:
-        description: |-
-          An array of content parts that form the message body. A message can be
-          composed of multiple parts of different types (e.g., text and files).
-        items:
-          $ref: '#/definitions/Part'
-        type: array
-      referenceTaskIds:
-        description: A list of other task IDs that this message references for additional context.
-        items:
-          type: string
-        type: array
-      role:
-        description: Identifies the sender of the message. `user` for the client, `agent` for the service.
-        enum:
-          - agent
-          - user
-        type: string
-      taskId:
-        description: The ID of the task this message is part of. Can be omitted for the first message of a new task.
-        type: string
-    required:
-      - kind
-      - messageId
-      - parts
-      - role
-    type: object
-  MessageSendConfiguration:
-    description: Defines configuration options for a `message/send` or `message/stream` request.
-    properties:
-      acceptedOutputModes:
-        description: A list of output MIME types the client is prepared to accept in the response.
-        items:
-          type: string
-        type: array
-      blocking:
-        description: If true, the client will wait for the task to complete. The server may reject this if the task is long-running.
-        type: boolean
-      historyLength:
-        description: The number of most recent messages from the task's history to retrieve in the response.
-        type: integer
-      pushNotificationConfig:
-        $ref: '#/definitions/PushNotificationConfig'
-        description: Configuration for the agent to send push notifications for updates after the initial response.
-    type: object
-  MessageSendParams:
-    description: |-
-      Defines the parameters for a request to send a message to an agent. This can be used
-      to create a new task, continue an existing one, or restart a task.
-    properties:
-      configuration:
-        $ref: '#/definitions/MessageSendConfiguration'
-        description: Optional configuration for the send request.
-      message:
-        $ref: '#/definitions/Message'
-        description: The message object being sent to the agent.
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions.
-        type: object
-    required:
-      - message
-    type: object
-  MethodNotFoundError:
-    description: An error indicating that the requested method does not exist or is not available.
-    properties:
-      code:
-        const: -32601
-        description: The error code for a method not found error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Method not found
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  MutualTLSSecurityScheme:
+  MutualTlsSecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using mTLS authentication.
     properties:
       description:
         description: An optional description for the security scheme.
         type: string
-      type:
-        const: mutualTLS
-        description: The type of the security scheme. Must be 'mutualTLS'.
-        type: string
     required:
-      - type
+      - description
+    title: Mutual Tls Security Scheme
     type: object
   OAuth2SecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using OAuth 2.0.
     properties:
       description:
@@ -1316,90 +418,221 @@ definitions:
       oauth2MetadataUrl:
         description: |-
           URL to the oauth2 authorization server metadata
-          [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414). TLS is required.
-        type: string
-      type:
-        const: oauth2
-        description: The type of the security scheme. Must be 'oauth2'.
+           RFC8414 (https://datatracker.ietf.org/doc/html/rfc8414). TLS is required.
         type: string
     required:
       - flows
-      - type
+    title: O Auth2 Security Scheme
     type: object
   OAuthFlows:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines the configuration for the supported OAuth 2.0 flows.
     properties:
       authorizationCode:
         $ref: '#/definitions/AuthorizationCodeOAuthFlow'
-        description: Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0.
+        description: Configuration for the OAuth Authorization Code flow.
       clientCredentials:
         $ref: '#/definitions/ClientCredentialsOAuthFlow'
-        description: Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0.
+        description: Configuration for the OAuth Client Credentials flow.
       implicit:
         $ref: '#/definitions/ImplicitOAuthFlow'
         description: Configuration for the OAuth Implicit flow.
       password:
         $ref: '#/definitions/PasswordOAuthFlow'
         description: Configuration for the OAuth Resource Owner Password flow.
+    title: O Auth Flows
     type: object
   OpenIdConnectSecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines a security scheme using OpenID Connect.
     properties:
       description:
         description: An optional description for the security scheme.
         type: string
       openIdConnectUrl:
-        description: The OpenID Connect Discovery URL for the OIDC provider's metadata.
-        type: string
-      type:
-        const: openIdConnect
-        description: The type of the security scheme. Must be 'openIdConnect'.
+        description: |-
+          The OpenID Connect Discovery URL for the OIDC provider's metadata.
+           See: https://openid.net/specs/openid-connect-discovery-1_0.html
         type: string
     required:
       - openIdConnectUrl
-      - type
-    type: object
-  Part:
-    anyOf:
-      - $ref: '#/definitions/TextPart'
-      - $ref: '#/definitions/FilePart'
-      - $ref: '#/definitions/DataPart'
-    description: |-
-      A discriminated union representing a part of a message or artifact, which can
-      be text, a file, or structured data.
-  PartBase:
-    description: Defines base properties common to all message or artifact parts.
-    properties:
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with this part.
-        type: object
+    title: Open Id Connect Security Scheme
     type: object
   PasswordOAuthFlow:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: Defines configuration details for the OAuth 2.0 Resource Owner Password flow.
     properties:
       refreshUrl:
-        description: The URL to be used for obtaining refresh tokens. This MUST be a URL.
+        description: The URL to be used for obtaining refresh tokens.
         type: string
       scopes:
         additionalProperties:
           type: string
-        description: |-
-          The available scopes for the OAuth2 security scheme. A map between the scope
-          name and a short description for it.
+        description: The available scopes for the OAuth2 security scheme.
+        propertyNames:
+          type: string
         type: object
       tokenUrl:
-        description: The token URL to be used for this flow. This MUST be a URL.
+        description: The token URL to be used for this flow.
         type: string
     required:
-      - scopes
       - tokenUrl
+      - scopes
+    title: PasswordO Auth Flow
     type: object
-  PushNotificationAuthenticationInfo:
-    description: Defines authentication details for a push notification endpoint.
+  Security:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    properties:
+      schemes:
+        additionalProperties:
+          $ref: '#/definitions/StringList'
+        propertyNames:
+          type: string
+        type: object
+    title: Security
+    type: object
+  SecurityScheme:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      Defines a security scheme that can be used to secure an agent's endpoints.
+       This is a discriminated union type based on the OpenAPI 3.2 Security Scheme Object.
+       See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object
+    properties:
+      apiKeySecurityScheme:
+        $ref: '#/definitions/APIKeySecurityScheme'
+        description: API key-based authentication.
+      httpAuthSecurityScheme:
+        $ref: '#/definitions/HTTPAuthSecurityScheme'
+        description: HTTP authentication (Basic, Bearer, etc.).
+      mtlsSecurityScheme:
+        $ref: '#/definitions/MutualTlsSecurityScheme'
+        description: Mutual TLS authentication.
+      oauth2SecurityScheme:
+        $ref: '#/definitions/OAuth2SecurityScheme'
+        description: OAuth 2.0 authentication.
+      openIdConnectSecurityScheme:
+        $ref: '#/definitions/OpenIdConnectSecurityScheme'
+        description: OpenID Connect authentication.
+    title: Security Scheme
+    type: object
+  StringList:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+    properties:
+      list:
+        items:
+          type: string
+        type: array
+    title: String List
+    type: object
+  Artifact:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Artifacts represent task outputs.
+    properties:
+      artifactId:
+        description: |-
+          Unique identifier (e.g. UUID) for the artifact. It must be at least unique
+           within a task.
+        type: string
+      description:
+        description: A human readable description of the artifact, optional.
+        type: string
+      extensions:
+        description: The URIs of extensions that are present or contributed to this Artifact.
+        items:
+          type: string
+        type: array
+      metadata:
+        $ref: '#/definitions/Struct'
+        description: Optional metadata included with the artifact.
+      name:
+        description: A human readable name for the artifact.
+        type: string
+      parts:
+        description: The content of the artifact. Must contain at least one part.
+        items:
+          $ref: '#/definitions/Part'
+        type: array
+    required:
+      - artifactId
+      - parts
+    title: Artifact
+    type: object
+  DataPart:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: DataPart represents a structured blob.
+    properties:
+      data:
+        $ref: '#/definitions/Struct'
+        description: A JSON object containing arbitrary data.
+    title: Data Part
+    type: object
+    required:
+      - data
+  FilePart:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      FilePart represents the different ways files can be provided. If files are
+       small, directly feeding the bytes is supported via file_with_bytes. If the
+       file is large, the agent should read the content as appropriate directly
+       from the file_with_uri source.
+    properties:
+      fileWithBytes:
+        description: The base64-encoded content of the file.
+        pattern: ^[A-Za-z0-9+/]*={0,2}$
+        type: string
+      fileWithUri:
+        description: A URL pointing to the file's content.
+        type: string
+      mediaType:
+        description: The media type of the file (e.g., "application/pdf").
+        type: string
+      name:
+        description: An optional name for the file (e.g., "document.pdf").
+        type: string
+    required:
+      - mediaType
+      - name
+    title: File Part
+    type: object
+  Part:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      Part represents a container for a section of communication content.
+       Parts can be purely textual, some sort of file (image, video, etc) or
+       a structured data blob (i.e. JSON).
+    properties:
+      data:
+        $ref: '#/definitions/DataPart'
+        description: The structured data content.
+      file:
+        $ref: '#/definitions/FilePart'
+        description: The file content, represented as either a URI or as base64-encoded bytes.
+      metadata:
+        $ref: '#/definitions/Struct'
+        description: Optional metadata associated with this part.
+      text:
+        description: The string content of the text part.
+        type: string
+    title: Part
+    type: object
+  AuthenticationInfo:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Defines authentication details, used for push notifications.
     properties:
       credentials:
-        description: Optional credentials required by the push notification endpoint.
+        description: Optional credentials
         type: string
       schemes:
         description: A list of supported authentication schemes (e.g., 'Basic', 'Bearer').
@@ -1408,604 +641,594 @@ definitions:
         type: array
     required:
       - schemes
+    title: Authentication Info
+    type: object
+  CancelTaskRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Represents a request for the `tasks/cancel` method.
+    properties:
+      name:
+        description: |-
+          The resource name of the task to cancel.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+      - name
+    title: Cancel Task Request
+    type: object
+  DeleteTaskPushNotificationConfigRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Represents a request for the `tasks/pushNotificationConfig/delete` method.
+    properties:
+      name:
+        description: |-
+          The resource name of the config to delete.
+           Format: tasks/{task_id}/pushNotificationConfigs/{config_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+      - name
+    title: Delete Task Push Notification Config Request
+    type: object
+  GetExtendedAgentCardRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    properties:
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+    title: Get Extended Agent Card Request
+    type: object
+  GetTaskPushNotificationConfigRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    properties:
+      name:
+        description: |-
+          The resource name of the config to retrieve.
+           Format: tasks/{task_id}/pushNotificationConfigs/{config_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+      - name
+    title: Get Task Push Notification Config Request
+    type: object
+  GetTaskRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Represents a request for the `tasks/get` method.
+    properties:
+      historyLength:
+        description: The maximum number of messages to include in the history.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      name:
+        description: |-
+          The resource name of the task.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - name
+    title: Get Task Request
+    type: object
+  ListTaskPushNotificationConfigRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    properties:
+      pageSize:
+        description: The maximum number of configurations to return.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      pageToken:
+        description: A page token received from a previous ListTaskPushNotificationConfigRequest call.
+        type: string
+      parent:
+        description: |-
+          The parent task resource.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+      - parent
+      - pageSize
+      - pageToken
+    title: List Task Push Notification Config Request
+    type: object
+  ListTaskPushNotificationConfigResponse:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      Represents a successful response for the `tasks/pushNotificationConfig/list`
+       method.
+    properties:
+      configs:
+        description: The list of push notification configurations.
+        items:
+          $ref: '#/definitions/TaskPushNotificationConfig'
+        type: array
+      nextPageToken:
+        description: |-
+          A token, which can be sent as `page_token` to retrieve the next page.
+           If this field is omitted, there are no subsequent pages.
+        type: string
+    required:
+      - nextPageToken
+    title: List Task Push Notification Config Response
     type: object
   PushNotificationConfig:
-    description: Defines the configuration for setting up push notifications for task updates.
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Configuration for setting up push notifications for task updates.
     properties:
       authentication:
-        $ref: '#/definitions/PushNotificationAuthenticationInfo'
-        description: Optional authentication details for the agent to use when calling the notification URL.
+        $ref: '#/definitions/AuthenticationInfo'
+        description: Information about the authentication to sent with the notification
       id:
-        description: |-
-          A unique identifier (e.g. UUID) for the push notification configuration, set by the client
-          to support multiple notification callbacks.
+        description: A unique identifier (e.g. UUID) for this push notification.
         type: string
       token:
-        description: A unique token for this task or session to validate incoming push notifications.
+        description: Token unique for this task/session
         type: string
       url:
-        description: The callback URL where the agent should send push notifications.
+        description: Url to send the notification too
         type: string
     required:
       - url
+    title: Push Notification Config
     type: object
-  PushNotificationNotSupportedError:
-    description: An A2A-specific error indicating that the agent does not support push notifications.
+  TaskPushNotificationConfig:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      A container associating a push notification configuration with a specific
+       task.
     properties:
-      code:
-        const: -32003
-        description: The error code for when push notifications are not supported.
-        type: integer
-      data:
+      name:
         description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Push Notification is not supported
-        description: The error message.
+          The resource name of the config.
+           Format: tasks/{task_id}/pushNotificationConfigs/{config_id}
+        type: string
+      pushNotificationConfig:
+        $ref: '#/definitions/PushNotificationConfig'
+        description: The push notification configuration details.
+    required:
+      - name
+      - pushNotificationConfig
+    title: Task Push Notification Config
+    type: object
+  ListTasksRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Parameters for listing tasks with optional filtering criteria.
+    properties:
+      contextId:
+        description: Filter tasks by context ID to get tasks from a specific conversation or session.
+        type: string
+      historyLength:
+        description: The maximum number of messages to include in each task's history.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      includeArtifacts:
+        description: |-
+          Whether to include artifacts in the returned tasks.
+           Defaults to false to reduce payload size.
+        type: boolean
+      lastUpdatedAfter:
+        description: |-
+          Filter tasks updated after this timestamp (milliseconds since epoch).
+           Only tasks with a last updated time greater than or equal to this value will be returned.
+        type: integer
+      pageSize:
+        description: |-
+          Maximum number of tasks to return. Must be between 1 and 100.
+           Defaults to 50 if not specified.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      pageToken:
+        description: Token for pagination. Use the next_page_token from a previous ListTasksResponse.
+        type: string
+      status:
+        description: Filter tasks by their current status state.
+        enum:
+          - TASK_STATE_UNSPECIFIED
+          - TASK_STATE_SUBMITTED
+          - TASK_STATE_WORKING
+          - TASK_STATE_COMPLETED
+          - TASK_STATE_FAILED
+          - TASK_STATE_CANCELLED
+          - TASK_STATE_INPUT_REQUIRED
+          - TASK_STATE_REJECTED
+          - TASK_STATE_AUTH_REQUIRED
+        title: Task State
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
         type: string
     required:
-      - code
-      - message
+      - tenant
+      - contextId
+      - status
+      - pageToken
+      - lastUpdatedAfter
+    title: List Tasks Request
     type: object
-  SecurityScheme:
-    anyOf:
-      - $ref: '#/definitions/APIKeySecurityScheme'
-      - $ref: '#/definitions/HTTPAuthSecurityScheme'
-      - $ref: '#/definitions/OAuth2SecurityScheme'
-      - $ref: '#/definitions/OpenIdConnectSecurityScheme'
-      - $ref: '#/definitions/MutualTLSSecurityScheme'
+  ListTasksResponse:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Result object for tasks/list method containing an array of tasks and pagination information.
+    properties:
+      nextPageToken:
+        description: Token for retrieving the next page. Empty string if no more results.
+        type: string
+      pageSize:
+        description: The size of page requested.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      tasks:
+        description: Array of tasks matching the specified criteria.
+        items:
+          $ref: '#/definitions/Task'
+        type: array
+      totalSize:
+        description: Total number of tasks available (before pagination).
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+    required:
+      - tasks
+      - nextPageToken
+      - pageSize
+      - totalSize
+    title: List Tasks Response
+    type: object
+  Message:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
-      Defines a security scheme that can be used to secure an agent's endpoints.
-      This is a discriminated union type based on the OpenAPI 3.0 Security Scheme Object.
-  SecuritySchemeBase:
-    description: Defines base properties shared by all security scheme objects.
+      Message is one unit of communication between client and server. It is
+       associated with a context and optionally a task. Since the server is
+       responsible for the context definition, it must always provide a context_id
+       in its messages. The client can optionally provide the context_id if it
+       knows the context to associate the message to. Similarly for task_id,
+       except the server decides if a task is created and whether to include the
+       task_id.
     properties:
-      description:
-        description: An optional description for the security scheme.
+      contextId:
+        description: |-
+          The context id of the message. This is optional and if set, the message
+           will be associated with the given context.
         type: string
-    type: object
-  SendMessageRequest:
-    description: Represents a JSON-RPC request for the `message/send` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
+      extensions:
+        description: The URIs of extensions that are present or contributed to this Message.
+        items:
+          type: string
+        type: array
+      messageId:
+        description: |-
+          The unique identifier (e.g. UUID) of the message. This is required and
+           created by the message creator.
         type: string
-      method:
-        const: message/send
-        description: The method name. Must be 'message/send'.
+      metadata:
+        $ref: '#/definitions/Struct'
+        description: |-
+          protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
+           Any optional metadata to provide along with the message.
+      parts:
+        description: |-
+          protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+           Parts is the container of the message content.
+        items:
+          $ref: '#/definitions/Part'
+        type: array
+      referenceTaskIds:
+        description: A list of task IDs that this message references for additional context.
+        items:
+          type: string
+        type: array
+      role:
+        description: Identifies the sender of the message.
+        enum:
+          - ROLE_UNSPECIFIED
+          - ROLE_USER
+          - ROLE_AGENT
+        title: Role
         type: string
-      params:
-        $ref: '#/definitions/MessageSendParams'
-        description: The parameters for sending a message.
+      taskId:
+        description: |-
+          The task id of the message. This is optional and if set, the message
+           will be associated with the given task.
+        type: string
     required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  SendMessageResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/SendMessageSuccessResponse'
-    description: Represents a JSON-RPC response for the `message/send` method.
-  SendMessageSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `message/send` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        anyOf:
-          - $ref: '#/definitions/Task'
-          - $ref: '#/definitions/Message'
-        description: The result, which can be a direct reply Message or the initial Task object.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  SendStreamingMessageRequest:
-    description: Represents a JSON-RPC request for the `message/stream` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: message/stream
-        description: The method name. Must be 'message/stream'.
-        type: string
-      params:
-        $ref: '#/definitions/MessageSendParams'
-        description: The parameters for sending a message.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  SendStreamingMessageResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/SendStreamingMessageSuccessResponse'
-    description: Represents a JSON-RPC response for the `message/stream` method.
-  SendStreamingMessageSuccessResponse:
-    description: |-
-      Represents a successful JSON-RPC response for the `message/stream` method.
-      The server may send multiple response objects for a single request.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        anyOf:
-          - $ref: '#/definitions/Task'
-          - $ref: '#/definitions/Message'
-          - $ref: '#/definitions/TaskStatusUpdateEvent'
-          - $ref: '#/definitions/TaskArtifactUpdateEvent'
-        description: The result, which can be a Message, Task, or a streaming update event.
-    required:
-      - id
-      - jsonrpc
-      - result
-    type: object
-  SetTaskPushNotificationConfigRequest:
-    description: Represents a JSON-RPC request for the `tasks/pushNotificationConfig/set` method.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/pushNotificationConfig/set
-        description: The method name. Must be 'tasks/pushNotificationConfig/set'.
-        type: string
-      params:
-        $ref: '#/definitions/TaskPushNotificationConfig'
-        description: The parameters for setting the push notification configuration.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  SetTaskPushNotificationConfigResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/SetTaskPushNotificationConfigSuccessResponse'
-    description: Represents a JSON-RPC response for the `tasks/pushNotificationConfig/set` method.
-  SetTaskPushNotificationConfigSuccessResponse:
-    description: Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/set` method.
-    properties:
-      id:
-        description: The identifier established by the client.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/TaskPushNotificationConfig'
-        description: The result, containing the configured push notification settings.
-    required:
-      - id
-      - jsonrpc
-      - result
+      - messageId
+      - role
+      - parts
+    title: Message
     type: object
   Task:
-    description: Represents a single, stateful operation or conversation between a client and an agent.
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      Task is the core unit of action for A2A. It has a current status
+       and when results are created for the task they are stored in the
+       artifact. If there are multiple turns for a task, these are stored in
+       history.
     properties:
       artifacts:
-        description: A collection of artifacts generated by the agent during the execution of the task.
+        description: A set of output artifacts for a Task.
         items:
           $ref: '#/definitions/Artifact'
         type: array
       contextId:
-        description: A server-generated unique identifier (e.g. UUID) for maintaining context across multiple related tasks or interactions.
+        description: |-
+          Unique identifier (e.g. UUID) for the contextual collection of interactions
+           (tasks and messages). Created by the A2A server.
         type: string
       history:
-        description: An array of messages exchanged during the task, representing the conversation history.
+        description: |-
+          protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+           The history of interactions from a task.
         items:
           $ref: '#/definitions/Message'
         type: array
       id:
-        description: A unique identifier (e.g. UUID) for the task, generated by the server for a new task.
-        type: string
-      kind:
-        const: task
-        description: The type of this object, used as a discriminator. Always 'task' for a Task.
+        description: |-
+          Unique identifier (e.g. UUID) for the task, generated by the server for a
+           new task.
         type: string
       metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions. The key is an extension-specific identifier.
-        type: object
+        $ref: '#/definitions/Struct'
+        description: |-
+          protolint:enable REPEATED_FIELD_NAMES_PLURALIZED
+           A key/value object to store custom metadata about a task.
       status:
         $ref: '#/definitions/TaskStatus'
-        description: The current status of the task, including its state and a descriptive message.
+        description: The current status of a Task, including state and a message.
     required:
-      - contextId
       - id
-      - kind
+      - contextId
       - status
+    title: Task
+    type: object
+  TaskStatus:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: A container for the status of a task
+    properties:
+      message:
+        $ref: '#/definitions/Message'
+        description: A message associated with the status.
+      state:
+        description: The current state of this task.
+        enum:
+          - TASK_STATE_UNSPECIFIED
+          - TASK_STATE_SUBMITTED
+          - TASK_STATE_WORKING
+          - TASK_STATE_COMPLETED
+          - TASK_STATE_FAILED
+          - TASK_STATE_CANCELLED
+          - TASK_STATE_INPUT_REQUIRED
+          - TASK_STATE_REJECTED
+          - TASK_STATE_AUTH_REQUIRED
+        title: Task State
+        type: string
+      timestamp:
+        $ref: '#/definitions/Timestamp'
+        description: |-
+          ISO 8601 Timestamp when the status was recorded.
+           Example: "2023-10-27T10:00:00Z"
+    required:
+      - state
+    title: Task Status
+    type: object
+  Timestamp:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    format: date-time
+    title: Timestamp
+    type: string
+  SendMessageConfiguration:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Configuration of a send message request.
+    properties:
+      acceptedOutputModes:
+        description: A list of media types the client is prepared to accept for response parts. Agents SHOULD use this to tailor their output.
+        items:
+          type: string
+        type: array
+      blocking:
+        description: If true, the operation waits until the task reaches a terminal state before returning. Default is false.
+        type: boolean
+      historyLength:
+        description: The maximum number of messages to include in the history.
+        maximum: 2147483647
+        minimum: -2147483648
+        type: integer
+      pushNotificationConfig:
+        $ref: '#/definitions/PushNotificationConfig'
+        description: Configuration for the agent to send push notifications for task updates.
+    required:
+      - blocking
+    title: Send Message Configuration
+    type: object
+  SendMessageRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: |-
+      /////////// Request Messages ///////////
+       Represents a request for the `message/send` method.
+    properties:
+      configuration:
+        $ref: '#/definitions/SendMessageConfiguration'
+        description: Configuration for the send request.
+      message:
+        $ref: '#/definitions/Message'
+        description: The message to send to the agent.
+      metadata:
+        $ref: '#/definitions/Struct'
+        description: A flexible key-value map for passing additional context or parameters.
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - tenant
+    title: Send Message Request
+    type: object
+  SendMessageResponse:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: ////// Response Messages ///////////
+    properties:
+      message:
+        $ref: '#/definitions/Message'
+      task:
+        $ref: '#/definitions/Task'
+    title: Send Message Response
+    type: object
+  SetTaskPushNotificationConfigRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: Represents a request for the `tasks/pushNotificationConfig/set` method.
+    properties:
+      config:
+        $ref: '#/definitions/TaskPushNotificationConfig'
+        description: The configuration to create.
+      configId:
+        description: The ID for the new config.
+        type: string
+      parent:
+        description: |-
+          The parent task resource for this config.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
+        type: string
+    required:
+      - parent
+      - configId
+      - config
+    title: Set Task Push Notification Config Request
+    type: object
+  StreamResponse:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
+    description: A wrapper object used in streaming operations to encapsulate different types of response data.
+    properties:
+      artifactUpdate:
+        $ref: '#/definitions/TaskArtifactUpdateEvent'
+        description: An event indicating a task artifact update.
+      message:
+        $ref: '#/definitions/Message'
+        description: A Message object containing a message from the agent.
+      statusUpdate:
+        $ref: '#/definitions/TaskStatusUpdateEvent'
+        description: An event indicating a task status update.
+      task:
+        $ref: '#/definitions/Task'
+        description: A Task object containing the current state of the task.
+    title: Stream Response
     type: object
   TaskArtifactUpdateEvent:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
-      An event sent by the agent to notify the client that an artifact has been
-      generated or updated. This is typically used in streaming models.
+      TaskArtifactUpdateEvent represents a task delta where an artifact has
+       been generated.
     properties:
       append:
-        description: If true, the content of this artifact should be appended to a previously sent artifact with the same ID.
+        description: |-
+          If true, the content of this artifact should be appended to a previously
+           sent artifact with the same ID.
         type: boolean
       artifact:
         $ref: '#/definitions/Artifact'
         description: The artifact that was generated or updated.
       contextId:
-        description: The context ID associated with the task.
-        type: string
-      kind:
-        const: artifact-update
-        description: The type of this event, used as a discriminator. Always 'artifact-update'.
+        description: The id of the context that this task belongs to.
         type: string
       lastChunk:
         description: If true, this is the final chunk of the artifact.
         type: boolean
       metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions.
-        type: object
+        $ref: '#/definitions/Struct'
+        description: Optional metadata associated with the artifact update.
       taskId:
-        description: The ID of the task this artifact belongs to.
+        description: The id of the task for this artifact.
         type: string
     required:
-      - artifact
+      - taskId
       - contextId
-      - kind
-      - taskId
-    type: object
-  TaskIdParams:
-    description: Defines parameters containing a task ID, used for simple task operations.
-    properties:
-      id:
-        description: The unique identifier (e.g. UUID) of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-    required:
-      - id
-    type: object
-  TaskListParams:
-    description: Parameters for listing tasks with optional filtering and pagination.
-    properties:
-      limit:
-        description: Maximum number of tasks to return (default 50, max 100).
-        type: integer
-        minimum: 1
-        maximum: 100
-        default: 50
-      offset:
-        description: Number of tasks to skip for pagination (default 0).
-        type: integer
-        minimum: 0
-        default: 0
-      state:
-        description: Filter tasks by state (optional).
-        $ref: '#/definitions/TaskState'
-      contextId:
-        description: Filter tasks by context ID (optional).
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Request-specific metadata.
-        type: object
-    type: object
-  TaskList:
-    description: List of tasks with pagination information.
-    properties:
-      tasks:
-        description: Array of tasks matching the query.
-        items:
-          $ref: '#/definitions/Task'
-        type: array
-      total:
-        description: Total number of tasks available (for pagination).
-        type: integer
-      limit:
-        description: Maximum number of tasks returned in this response.
-        type: integer
-      offset:
-        description: Number of tasks skipped for this response.
-        type: integer
-    required:
-      - tasks
-      - total
-      - limit
-      - offset
-    type: object
-  TaskNotCancelableError:
-    description: An A2A-specific error indicating that the task is in a state where it cannot be canceled.
-    properties:
-      code:
-        const: -32002
-        description: The error code for a task that cannot be canceled.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Task cannot be canceled
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  TaskNotFoundError:
-    description: An A2A-specific error indicating that the requested task ID was not found.
-    properties:
-      code:
-        const: -32001
-        description: The error code for a task not found error.
-        type: integer
-      data:
-        description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: Task not found
-        description: The error message.
-        type: string
-    required:
-      - code
-      - message
-    type: object
-  TaskPushNotificationConfig:
-    description: A container associating a push notification configuration with a specific task.
-    properties:
-      pushNotificationConfig:
-        $ref: '#/definitions/PushNotificationConfig'
-        description: The push notification configuration for this task.
-      taskId:
-        description: The unique identifier (e.g. UUID) of the task.
-        type: string
-    required:
-      - pushNotificationConfig
-      - taskId
-    type: object
-  TaskQueryParams:
-    description: Defines parameters for querying a task, with an option to limit history length.
-    properties:
-      historyLength:
-        description: The number of most recent messages from the task's history to retrieve.
-        type: integer
-      id:
-        description: The unique identifier (e.g. UUID) of the task.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with the request.
-        type: object
-    required:
-      - id
-    type: object
-  TaskResubscriptionRequest:
-    description: Represents a JSON-RPC request for the `tasks/resubscribe` method, used to resume a streaming connection.
-    properties:
-      id:
-        description: The identifier for this request.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: The version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/resubscribe
-        description: The method name. Must be 'tasks/resubscribe'.
-        type: string
-      params:
-        $ref: '#/definitions/TaskIdParams'
-        description: The parameters identifying the task to resubscribe to.
-    required:
-      - id
-      - jsonrpc
-      - method
-      - params
-    type: object
-  TaskState:
-    description: Defines the lifecycle states of a Task.
-    enum:
-      - submitted
-      - working
-      - input-required
-      - completed
-      - canceled
-      - failed
-      - rejected
-      - auth-required
-      - unknown
-    type: string
-  TaskStatus:
-    description: Represents the status of a task at a specific point in time.
-    properties:
-      message:
-        $ref: '#/definitions/Message'
-        description: An optional, human-readable message providing more details about the current status.
-      state:
-        $ref: '#/definitions/TaskState'
-        description: The current state of the task's lifecycle.
-      timestamp:
-        description: An ISO 8601 datetime string indicating when this status was recorded.
-        examples:
-          - '2023-10-27T10:00:00Z'
-        type: string
-    required:
-      - state
+      - artifact
+    title: Task Artifact Update Event
     type: object
   TaskStatusUpdateEvent:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     description: |-
-      An event sent by the agent to notify the client of a change in a task's status.
-      This is typically used in streaming or subscription models.
+      An event sent by the agent to notify the client of a change in a task's
+       status.
     properties:
       contextId:
-        description: The context ID associated with the task.
+        description: The id of the context that the task belongs to
         type: string
       final:
         description: If true, this is the final event in the stream for this interaction.
         type: boolean
-      kind:
-        const: status-update
-        description: The type of this event, used as a discriminator. Always 'status-update'.
-        type: string
       metadata:
-        additionalProperties: {}
-        description: Optional metadata for extensions.
-        type: object
+        $ref: '#/definitions/Struct'
+        description: Optional metadata to associate with the task update.
       status:
         $ref: '#/definitions/TaskStatus'
         description: The new status of the task.
       taskId:
-        description: The ID of the task that was updated.
+        description: The id of the task that is changed
         type: string
     required:
-      - contextId
-      - final
-      - kind
-      - status
       - taskId
+      - contextId
+      - status
+      - final
+    title: Task Status Update Event
     type: object
-  TextPart:
-    description: Represents a text segment within a message or artifact.
+  SubscribeToTaskRequest:
+    $schema: https://json-schema.org/draft/2020-12/schema
+    additionalProperties: false
     properties:
-      kind:
-        const: text
-        description: The type of this part, used as a discriminator. Always 'text'.
-        type: string
-      metadata:
-        additionalProperties: {}
-        description: Optional metadata associated with this part.
-        type: object
-      text:
-        description: The string content of the text part.
-        type: string
-    required:
-      - kind
-      - text
-    type: object
-  TransportProtocol:
-    description: Supported A2A transport protocols.
-    enum:
-      - JSONRPC
-      - GRPC
-      - HTTP+JSON
-    type: string
-  UnsupportedOperationError:
-    description: An A2A-specific error indicating that the requested operation is not supported by the agent.
-    properties:
-      code:
-        const: -32004
-        description: The error code for an unsupported operation.
-        type: integer
-      data:
+      name:
         description: |-
-          A primitive or structured value containing additional information about the error.
-          This may be omitted.
-      message:
-        default: This operation is not supported
-        description: The error message.
+          The resource name of the task to subscribe to.
+           Format: tasks/{task_id}
+        type: string
+      tenant:
+        description: Optional tenant, provided as a path parameter.
         type: string
     required:
-      - code
-      - message
-    type: object
-  ListTasksRequest:
-    description: JSON-RPC request model for the 'tasks/list' method.
-    properties:
-      id:
-        description: |-
-          An identifier established by the Client that MUST contain a String, Number.
-          Numbers SHOULD NOT contain fractional parts.
-        type:
-          - string
-          - integer
-      jsonrpc:
-        const: '2.0'
-        description: Specifies the version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      method:
-        const: tasks/list
-        description: A String containing the name of the method to be invoked.
-        type: string
-      params:
-        $ref: '#/definitions/TaskListParams'
-        description: A Structured value that holds the parameter values to be used during the invocation of the method.
-    required:
-      - id
-      - jsonrpc
-      - method
-    type: object
-  ListTasksResponse:
-    anyOf:
-      - $ref: '#/definitions/JSONRPCErrorResponse'
-      - $ref: '#/definitions/ListTasksSuccessResponse'
-    description: JSON-RPC response for the 'tasks/list' method.
-  ListTasksSuccessResponse:
-    description: JSON-RPC success response for the 'tasks/list' method.
-    properties:
-      id:
-        description: |-
-          An identifier established by the Client that MUST contain a String, Number.
-          Numbers SHOULD NOT contain fractional parts.
-        type:
-          - string
-          - integer
-          - 'null'
-      jsonrpc:
-        const: '2.0'
-        description: Specifies the version of the JSON-RPC protocol. MUST be exactly "2.0".
-        type: string
-      result:
-        $ref: '#/definitions/TaskList'
-        description: The result object on success.
-    required:
-      - id
-      - jsonrpc
-      - result
+      - tenant
+      - name
+    title: Subscribe To Task Request
     type: object

--- a/server/agent_builder_test.go
+++ b/server/agent_builder_test.go
@@ -32,10 +32,7 @@ func TestAgentBuilder_Build_WithDefaults(t *testing.T) {
 	message := &types.Message{
 		Role: "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Hello",
-			},
+			types.CreateTextPart("Hello"),
 		},
 	}
 

--- a/server/agent_streamable.go
+++ b/server/agent_streamable.go
@@ -43,7 +43,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 			completedStatusEvent := cloudevents.NewEvent()
 			completedStatusEvent.SetType(types.EventTaskStatusChanged)
 			if err := completedStatusEvent.SetData(cloudevents.ApplicationJSON, types.TaskStatus{
-				State:   string(types.TaskStateCompleted),
+				State:   types.TaskStateCompleted,
 				Message: override,
 			}); err != nil {
 				a.logger.Error("failed to set completed status event data", zap.Error(err))
@@ -56,7 +56,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 		statusEvent := cloudevents.NewEvent()
 		statusEvent.SetType(types.EventTaskStatusChanged)
 		if err := statusEvent.SetData(cloudevents.ApplicationJSON, types.TaskStatus{
-			State: string(types.TaskStateWorking),
+			State: types.TaskStateWorking,
 		}); err != nil {
 			a.logger.Error("failed to set status event data", zap.Error(err))
 			return
@@ -176,7 +176,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 					cancelledStatusEvent := cloudevents.NewEvent()
 					cancelledStatusEvent.SetType(types.EventTaskStatusChanged)
 					if err := cancelledStatusEvent.SetData(cloudevents.ApplicationJSON, types.TaskStatus{
-						State: string(types.TaskStateCanceled),
+						State: types.TaskStateCancelled,
 					}); err != nil {
 						a.logger.Error("failed to set cancelled status event data", zap.Error(err))
 						return
@@ -188,7 +188,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 
 					interruptMessage := types.NewStreamingStatusMessage(
 						fmt.Sprintf("task-interrupted-%d", iteration),
-						string(types.TaskStateCanceled),
+						string(types.TaskStateCancelled),
 						nil,
 					)
 					interruptMessage.TaskID = taskID
@@ -206,7 +206,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 						failedStatusEvent := cloudevents.NewEvent()
 						failedStatusEvent.SetType(types.EventTaskStatusChanged)
 						if err := failedStatusEvent.SetData(cloudevents.ApplicationJSON, types.TaskStatus{
-							State: string(types.TaskStateFailed),
+							State: types.TaskStateFailed,
 						}); err != nil {
 							a.logger.Error("failed to set failed status event data", zap.Error(err))
 							return
@@ -370,8 +370,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 
 			if len(toolResultMessages) > 0 {
 				lastToolMessage := toolResultMessages[len(toolResultMessages)-1]
-				// Check if the message is input_required based on messageID prefix
-			if strings.HasPrefix(lastToolMessage.MessageID, "input-required") {
+				if strings.HasPrefix(lastToolMessage.MessageID, "input-required") {
 					a.logger.Debug("streaming completed - input required from user",
 						zap.Int("iteration", iteration),
 						zap.Int("final_message_count", len(currentMessages)))
@@ -396,7 +395,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 				completedStatusEvent := cloudevents.NewEvent()
 				completedStatusEvent.SetType(types.EventTaskStatusChanged)
 				if err := completedStatusEvent.SetData(cloudevents.ApplicationJSON, types.TaskStatus{
-					State:   string(types.TaskStateCompleted),
+					State:   types.TaskStateCompleted,
 					Message: finalAssistantMessage,
 				}); err != nil {
 					a.logger.Error("failed to set completed status event data", zap.Error(err))
@@ -422,7 +421,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 		canceledStatusEvent := cloudevents.NewEvent()
 		canceledStatusEvent.SetType(types.EventTaskStatusChanged)
 		if err := canceledStatusEvent.SetData(cloudevents.ApplicationJSON, types.TaskStatus{
-			State: string(types.TaskStateCanceled),
+			State: types.TaskStateCancelled,
 		}); err != nil {
 			a.logger.Error("failed to set canceled status event data", zap.Error(err))
 			return
@@ -434,7 +433,7 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 
 		interruptMessage := types.NewStreamingStatusMessage(
 			"max-iterations-reached",
-			string(types.TaskStateCanceled),
+			string(types.TaskStateCancelled),
 			nil,
 		)
 		interruptMessage.TaskID = taskID

--- a/server/agent_streamable_test.go
+++ b/server/agent_streamable_test.go
@@ -29,21 +29,21 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			streamingMessages: []types.Message{
 				{
 					MessageID: "chunk-1",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Hello "),
 					},
 				},
 				{
 					MessageID: "chunk-2",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("world!"),
 					},
 				},
 				{
 					MessageID: "chunk-3",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart(" How are you?"),
 					},
@@ -58,7 +58,7 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			streamingMessages: []types.Message{
 				{
 					MessageID: "chunk-1",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Single message response"),
 					},
@@ -73,21 +73,21 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			streamingMessages: []types.Message{
 				{
 					MessageID: "chunk-1",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Streaming "),
 					},
 				},
 				{
 					MessageID: "chunk-2",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("content..."),
 					},
 				},
 				{
 					MessageID: "assistant-final",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Final consolidated response"),
 					},
@@ -102,14 +102,14 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			streamingMessages: []types.Message{
 				{
 					MessageID: "chunk-1",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Processing your request..."),
 					},
 				},
 				{
 					MessageID: "input-req-1",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Please provide additional information"),
 					},
@@ -131,21 +131,21 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			streamingMessages: []types.Message{
 				{
 					MessageID: "user-1",
-					Role:      "user",
+					Role:      types.RoleUser,
 					Parts: []types.Part{
 						types.CreateTextPart("User message"),
 					},
 				},
 				{
 					MessageID: "chunk-1",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Assistant "),
 					},
 				},
 				{
 					MessageID: "chunk-2",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("response chunks"),
 					},
@@ -179,7 +179,7 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 
 				for i := len(allMessages) - 1; i >= 0; i-- {
 					msg := &allMessages[i]
-					if msg.Role == "assistant" && !strings.HasPrefix(msg.MessageID, "chunk-") {
+					if msg.Role == types.RoleAgent && !strings.HasPrefix(msg.MessageID, "chunk-") {
 						consolidatedMessage = msg
 						break
 					}
@@ -190,7 +190,7 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 					var finalMessageID string
 
 					for _, msg := range allMessages {
-						if msg.Role == "assistant" && strings.HasPrefix(msg.MessageID, "chunk-") {
+						if msg.Role == types.RoleAgent && strings.HasPrefix(msg.MessageID, "chunk-") {
 							for _, part := range msg.Parts {
 								if part.Text != nil {
 									fullContent += *part.Text
@@ -203,7 +203,7 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 					if fullContent != "" {
 						consolidatedMessage = &types.Message{
 							MessageID: strings.Replace(finalMessageID, "chunk-", "assistant-", 1),
-							Role:      "assistant",
+							Role:      types.RoleAgent,
 							Parts: []types.Part{
 								types.CreateTextPart(fullContent),
 							},
@@ -253,7 +253,7 @@ func TestStreamingMessageAccumulationPerformance(t *testing.T) {
 	for i := 0; i < numMessages; i++ {
 		messages[i] = types.Message{
 			MessageID: fmt.Sprintf("chunk-%d", i+1),
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateTextPart(fmt.Sprintf("Message %d ", i+1)),
 			},
@@ -264,7 +264,7 @@ func TestStreamingMessageAccumulationPerformance(t *testing.T) {
 
 	var fullContent string
 	for _, msg := range messages {
-		if msg.Role == "assistant" && strings.HasPrefix(msg.MessageID, "chunk-") {
+		if msg.Role == types.RoleAgent && strings.HasPrefix(msg.MessageID, "chunk-") {
 			for _, part := range msg.Parts {
 				if part.Text != nil {
 					fullContent += *part.Text
@@ -292,14 +292,14 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 			streamingMessages: []types.Message{
 				{
 					MessageID: "chunk-1",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart(""),
 					},
 				},
 				{
 					MessageID: "chunk-2",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Valid text"),
 					},
@@ -313,7 +313,7 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 			streamingMessages: []types.Message{
 				{
 					MessageID: "chunk-1",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("123"),
 					},
@@ -328,7 +328,7 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var fullContent string
 			for _, msg := range tt.streamingMessages {
-				if msg.Role == "assistant" && strings.HasPrefix(msg.MessageID, "chunk-") {
+				if msg.Role == types.RoleAgent && strings.HasPrefix(msg.MessageID, "chunk-") {
 					for _, part := range msg.Parts {
 						if part.Text != nil {
 							fullContent += *part.Text

--- a/server/agent_streamable_test.go
+++ b/server/agent_streamable_test.go
@@ -163,7 +163,7 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 				ID:        "test-task-123",
 				ContextID: "test-context-123",
 				Status: types.TaskStatus{
-					State: string(types.TaskStateWorking),
+					State: types.TaskStateWorking,
 				},
 				History: []types.Message{},
 			}
@@ -216,12 +216,11 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 				}
 			}
 
-			// Check if the message is input_required based on messageID prefix
-			if lastMessage != nil && strings.HasPrefix(lastMessage.MessageID, "input-required") {
-				task.Status.State = string(types.TaskStateInputRequired)
+			if lastMessage != nil && strings.HasPrefix(lastMessage.MessageID, "input-req") {
+				task.Status.State = types.TaskStateInputRequired
 				task.Status.Message = lastMessage
 			} else {
-				task.Status.State = string(types.TaskStateCompleted)
+				task.Status.State = types.TaskStateCompleted
 				if len(task.History) > 0 {
 					task.Status.Message = &task.History[len(task.History)-1]
 				} else {
@@ -320,7 +319,7 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 					},
 				},
 			},
-			expectedConsolidatedText: "",
+			expectedConsolidatedText: "123",
 			description:              "Should handle non-string text fields gracefully",
 		},
 	}

--- a/server/agent_streamable_test.go
+++ b/server/agent_streamable_test.go
@@ -216,7 +216,8 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 				}
 			}
 
-			if lastMessage != nil && lastMessage.Kind == "input_required" {
+			// Check if the message is input_required based on messageID prefix
+			if lastMessage != nil && strings.HasPrefix(lastMessage.MessageID, "input-required") {
 				task.Status.State = string(types.TaskStateInputRequired)
 				task.Status.Message = lastMessage
 			} else {
@@ -255,10 +256,7 @@ func TestStreamingMessageAccumulationPerformance(t *testing.T) {
 			MessageID: fmt.Sprintf("chunk-%d", i+1),
 			Role:      "assistant",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": fmt.Sprintf("Message %d ", i+1),
-				},
+				types.CreateTextPart(fmt.Sprintf("Message %d ", i+1)),
 			},
 		}
 	}
@@ -297,19 +295,14 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-						},
+						types.CreateTextPart(""),
 					},
 				},
 				{
 					MessageID: "chunk-2",
 					Role:      "assistant",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Valid text",
-						},
+						types.CreateTextPart("Valid text"),
 					},
 				},
 			},
@@ -323,7 +316,7 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{
-						types.CreateTextPart(123),
+						types.CreateTextPart("123"),
 					},
 				},
 			},

--- a/server/agent_streamable_test.go
+++ b/server/agent_streamable_test.go
@@ -28,7 +28,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			name: "streaming_chunks_accumulated_correctly",
 			streamingMessages: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -39,7 +38,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "chunk-2",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -50,7 +48,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "chunk-3",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -69,7 +66,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			name: "single_streaming_message",
 			streamingMessages: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -88,7 +84,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			name: "consolidated_message_with_final_assistant_message",
 			streamingMessages: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -99,7 +94,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "chunk-2",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -110,7 +104,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "assistant-final",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -129,7 +122,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			name: "input_required_message_handling",
 			streamingMessages: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -166,7 +158,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 			name: "mixed_chunk_and_non_chunk_messages",
 			streamingMessages: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "user-1",
 					Role:      "user",
 					Parts: []types.Part{
@@ -177,7 +168,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -188,7 +178,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "chunk-2",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -252,7 +241,6 @@ func TestStreamingMessageAccumulation(t *testing.T) {
 
 					if fullContent != "" {
 						consolidatedMessage = &types.Message{
-							Kind:      "message",
 							MessageID: strings.Replace(finalMessageID, "chunk-", "assistant-", 1),
 							Role:      "assistant",
 							Parts: []types.Part{
@@ -310,7 +298,6 @@ func TestStreamingMessageAccumulationPerformance(t *testing.T) {
 
 	for i := 0; i < numMessages; i++ {
 		messages[i] = types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("chunk-%d", i+1),
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -355,7 +342,6 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 			name: "malformed_message_parts",
 			streamingMessages: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -365,7 +351,6 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "chunk-2",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -383,7 +368,6 @@ func TestStreamingMessageAccumulationEdgeCases(t *testing.T) {
 			name: "non_string_text_field",
 			streamingMessages: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "chunk-1",
 					Role:      "assistant",
 					Parts: []types.Part{

--- a/server/agent_toolbox.go
+++ b/server/agent_toolbox.go
@@ -284,17 +284,16 @@ func executeCreateArtifact(ctx context.Context, args map[string]any) (string, er
 
 	artifactService.AddArtifactToTask(task, artifact)
 
-	if len(artifact.Parts) > 0 {
-		if filePart, ok := artifact.Parts[0].(types.FilePart); ok {
-			if fileWithURI, ok := filePart.File.(types.FileWithUri); ok {
-				return JSONTool(map[string]any{
-					"success":     true,
-					"message":     fmt.Sprintf("Artifact '%s' created successfully", name),
-					"artifact_id": artifact.ArtifactID,
-					"url":         fileWithURI.URI,
-					"filename":    filename,
-				})
-			}
+	if len(artifact.Parts) > 0 && artifact.Parts[0].File != nil {
+		filePart := artifact.Parts[0].File
+		if filePart.FileWithURI != nil {
+			return JSONTool(map[string]any{
+				"success":     true,
+				"message":     fmt.Sprintf("Artifact '%s' created successfully", name),
+				"artifact_id": artifact.ArtifactID,
+				"url":         *filePart.FileWithURI,
+				"filename":    filename,
+			})
 		}
 	}
 

--- a/server/callbacks_test.go
+++ b/server/callbacks_test.go
@@ -43,7 +43,6 @@ func TestCallbackExecutor_ExecuteBeforeAgent(t *testing.T) {
 					func(ctx context.Context, callbackContext *CallbackContext) *types.Message {
 						counter.Increment()
 						return &types.Message{
-							Kind:      "message",
 							MessageID: "test-skip",
 							Role:      "assistant",
 							Parts: []types.Part{
@@ -57,7 +56,6 @@ func TestCallbackExecutor_ExecuteBeforeAgent(t *testing.T) {
 				}
 			},
 			expected: &types.Message{
-				Kind:      "message",
 				MessageID: "test-skip",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -247,7 +245,6 @@ func TestCallbackExecutor_ExecuteAfterAgent(t *testing.T) {
 					}}
 			},
 			agentOutput: &types.Message{
-				Kind:      "message",
 				MessageID: "original",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -258,7 +255,6 @@ func TestCallbackExecutor_ExecuteAfterAgent(t *testing.T) {
 				},
 			},
 			expected: &types.Message{
-				Kind:      "message",
 				MessageID: "test-modified",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -305,7 +301,6 @@ func TestCallbackExecutor_ExecuteAfterAgent(t *testing.T) {
 				}
 			},
 			agentOutput: &types.Message{
-				Kind:      "message",
 				MessageID: "original",
 			},
 			expected: &types.Message{
@@ -395,7 +390,6 @@ func TestCallbackExecutor_ExecuteBeforeModel(t *testing.T) {
 						counter.Increment()
 						return &LLMResponse{
 							Content: &types.Message{
-								Kind:      "message",
 								MessageID: "test-blocked",
 								Role:      "assistant",
 								Parts: []types.Part{
@@ -412,7 +406,6 @@ func TestCallbackExecutor_ExecuteBeforeModel(t *testing.T) {
 			request: &LLMRequest{},
 			expected: &LLMResponse{
 				Content: &types.Message{
-					Kind:      "message",
 					MessageID: "test-blocked",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -655,7 +648,6 @@ func TestCallbackExecutor_ExecuteAfterModel(t *testing.T) {
 			},
 			response: &LLMResponse{
 				Content: &types.Message{
-					Kind:      "message",
 					MessageID: "original",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -668,7 +660,6 @@ func TestCallbackExecutor_ExecuteAfterModel(t *testing.T) {
 			},
 			expected: &LLMResponse{
 				Content: &types.Message{
-					Kind:      "message",
 					MessageID: "test-modified",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -717,7 +708,6 @@ func TestCallbackExecutor_ExecuteAfterModel(t *testing.T) {
 			},
 			response: &LLMResponse{
 				Content: &types.Message{
-					Kind:      "message",
 					MessageID: "original",
 				},
 			},

--- a/server/callbacks_test.go
+++ b/server/callbacks_test.go
@@ -44,7 +44,7 @@ func TestCallbackExecutor_ExecuteBeforeAgent(t *testing.T) {
 						counter.Increment()
 						return &types.Message{
 							MessageID: "test-skip",
-							Role:      "assistant",
+							Role:      types.RoleAgent,
 							Parts: []types.Part{
 								types.CreateTextPart("Execution skipped by callback"),
 							},
@@ -54,7 +54,7 @@ func TestCallbackExecutor_ExecuteBeforeAgent(t *testing.T) {
 			},
 			expected: &types.Message{
 				MessageID: "test-skip",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Execution skipped by callback"),
 				},
@@ -183,7 +183,7 @@ func TestCallbackExecutor_ExecuteAfterAgent(t *testing.T) {
 						return &types.Message{
 							ReferenceTaskIds: agentOutput.ReferenceTaskIds,
 							MessageID:        "test-modified",
-							Role:             "assistant",
+							Role:             types.RoleAgent,
 							Parts: []types.Part{
 								types.CreateTextPart("Response modified by callback"),
 							},
@@ -194,7 +194,7 @@ func TestCallbackExecutor_ExecuteAfterAgent(t *testing.T) {
 			agentOutput: &types.Message{
 				ReferenceTaskIds: []string{"1"},
 				MessageID:        "original",
-				Role:             "assistant",
+				Role:             types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Original response"),
 				},
@@ -202,7 +202,7 @@ func TestCallbackExecutor_ExecuteAfterAgent(t *testing.T) {
 			expected: &types.Message{
 				ReferenceTaskIds: []string{"1"},
 				MessageID:        "test-modified",
-				Role:             "assistant",
+				Role:             types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Response modified by callback"),
 				},
@@ -228,13 +228,13 @@ func TestCallbackExecutor_ExecuteAfterAgent(t *testing.T) {
 					func(ctx context.Context, callbackContext *CallbackContext, agentOutput *types.Message) *types.Message {
 						counter.Increment()
 						agentOutput.MessageID = "test-modified"
-						agentOutput.Role = "assistant"
+						agentOutput.Role = types.RoleAgent
 						return agentOutput
 					}}
 			},
 			agentOutput: &types.Message{
 				MessageID: "original",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Original response"),
 				},
@@ -245,7 +245,7 @@ func TestCallbackExecutor_ExecuteAfterAgent(t *testing.T) {
 				}
 				return &types.Message{
 					MessageID: "test-modified",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Original response"),
 					},
@@ -376,7 +376,7 @@ func TestCallbackExecutor_ExecuteBeforeModel(t *testing.T) {
 						return &LLMResponse{
 							Content: &types.Message{
 								MessageID: "test-blocked",
-								Role:      "assistant",
+								Role:      types.RoleAgent,
 								Parts: []types.Part{
 									types.CreateTextPart("LLM call blocked by callback"),
 								},
@@ -389,7 +389,7 @@ func TestCallbackExecutor_ExecuteBeforeModel(t *testing.T) {
 			expected: &LLMResponse{
 				Content: &types.Message{
 					MessageID: "test-blocked",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("LLM call blocked by callback"),
 					},
@@ -559,7 +559,7 @@ func TestCallbackExecutor_ExecuteAfterModel(t *testing.T) {
 						Content: &types.Message{
 							ReferenceTaskIds: llmResponse.Content.ReferenceTaskIds,
 							MessageID:        "test-modified",
-							Role:             "assistant",
+							Role:             types.RoleAgent,
 							Parts: []types.Part{
 								types.CreateTextPart("Response modified by callback"),
 							},
@@ -571,7 +571,7 @@ func TestCallbackExecutor_ExecuteAfterModel(t *testing.T) {
 				Content: &types.Message{
 					ReferenceTaskIds: []string{"1"},
 					MessageID:        "original",
-					Role:             "assistant",
+					Role:             types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Original response"),
 					},
@@ -581,7 +581,7 @@ func TestCallbackExecutor_ExecuteAfterModel(t *testing.T) {
 				Content: &types.Message{
 					ReferenceTaskIds: []string{"1"},
 					MessageID:        "test-modified",
-					Role:             "assistant",
+					Role:             types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Response modified by callback"),
 					},
@@ -608,14 +608,14 @@ func TestCallbackExecutor_ExecuteAfterModel(t *testing.T) {
 					func(ctx context.Context, callbackContext *CallbackContext, llmResponse *LLMResponse) *LLMResponse {
 						counter.Increment()
 						llmResponse.Content.MessageID = "test-modified"
-						llmResponse.Content.Role = "assistant"
+						llmResponse.Content.Role = types.RoleAgent
 						return llmResponse
 					}}
 			},
 			response: &LLMResponse{
 				Content: &types.Message{
 					MessageID: "original",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Original response"),
 					},
@@ -628,7 +628,7 @@ func TestCallbackExecutor_ExecuteAfterModel(t *testing.T) {
 				return &LLMResponse{
 					Content: &types.Message{
 						MessageID: "test-modified",
-						Role:      "assistant",
+						Role:      types.RoleAgent,
 						Parts: []types.Part{
 							types.CreateTextPart("Original response"),
 						},

--- a/server/push_notification_sender.go
+++ b/server/push_notification_sender.go
@@ -44,11 +44,16 @@ type TaskUpdateNotification struct {
 
 // SendTaskUpdate sends a push notification about a task update
 func (s *HTTPPushNotificationSender) SendTaskUpdate(ctx context.Context, config types.PushNotificationConfig, task *types.Task) error {
+	timestamp := ""
+	if task.Status.Timestamp != nil {
+		timestamp = time.Now().Format(time.RFC3339)
+	}
+
 	notification := TaskUpdateNotification{
 		Type:      "task_update",
 		TaskID:    task.ID,
 		State:     string(task.Status.State),
-		Timestamp: *task.Status.Timestamp,
+		Timestamp: timestamp,
 		Task:      task,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -572,7 +572,6 @@ func (s *A2AServerImpl) processQueuedTask(ctx context.Context, queuedTask *Queue
 		message = task.Status.Message
 	} else {
 		message = &types.Message{
-			Kind:      "message",
 			MessageID: uuid.New().String(),
 			Role:      "user",
 			Parts:     []types.Part{},
@@ -603,7 +602,6 @@ func (s *A2AServerImpl) processQueuedTask(ctx context.Context, queuedTask *Queue
 			zap.String("task_id", task.ID),
 			zap.String("context_id", task.ContextID))
 		updateErr := s.taskManager.UpdateError(task.ID, &types.Message{
-			Kind:      "message",
 			MessageID: uuid.New().String(),
 			Role:      "assistant",
 			Parts: []types.Part{

--- a/server/server.go
+++ b/server/server.go
@@ -603,7 +603,7 @@ func (s *A2AServerImpl) processQueuedTask(ctx context.Context, queuedTask *Queue
 			zap.String("context_id", task.ContextID))
 		updateErr := s.taskManager.UpdateError(task.ID, &types.Message{
 			MessageID: uuid.New().String(),
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateTextPart(err.Error()),
 			},

--- a/server/server.go
+++ b/server/server.go
@@ -605,10 +605,7 @@ func (s *A2AServerImpl) processQueuedTask(ctx context.Context, queuedTask *Queue
 			MessageID: uuid.New().String(),
 			Role:      "assistant",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": err.Error(),
-				},
+				types.CreateTextPart(err.Error()),
 			},
 		})
 		if updateErr != nil {

--- a/server/server_builder_test.go
+++ b/server/server_builder_test.go
@@ -412,7 +412,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 		agentCard := types.AgentCard{
 			Name:        "test-agent",
 			Description: "A test agent",
-			URL:         "http://test-agent:8080",
+			URL:         stringPtr("http://test-agent:8080"),
 			Version:     "0.1.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              boolPtr(false), // Streaming disabled, but still need background handler
@@ -435,7 +435,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 		agentCard := types.AgentCard{
 			Name:        "test-agent",
 			Description: "A test agent",
-			URL:         "http://test-agent:8080",
+			URL:         stringPtr("http://test-agent:8080"),
 			Version:     "0.1.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              boolPtr(true), // Streaming enabled
@@ -459,7 +459,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 		agentCard := types.AgentCard{
 			Name:        "test-agent",
 			Description: "A test agent",
-			URL:         "http://test-agent:8080",
+			URL:         stringPtr("http://test-agent:8080"),
 			Version:     "0.1.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              boolPtr(false), // Streaming disabled
@@ -483,7 +483,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 		agentCard := types.AgentCard{
 			Name:        "test-agent",
 			Description: "A test agent",
-			URL:         "http://test-agent:8080",
+			URL:         stringPtr("http://test-agent:8080"),
 			Version:     "0.1.0",
 			Capabilities: types.AgentCapabilities{
 				Streaming:              boolPtr(true), // Streaming enabled

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -60,7 +60,7 @@ func TestA2AServer_TaskManager_CreateTask(t *testing.T) {
 			state:     types.TaskStateWorking,
 			message: &types.Message{
 				MessageID: "test-message-2",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Processing your request"),
 				},
@@ -355,7 +355,7 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 			State: types.TaskStateCompleted,
 			Message: &types.Message{
 				MessageID: "response-msg",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Hello! I received your message."),
 				},
@@ -431,7 +431,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 			State: types.TaskStateCompleted,
 			Message: &types.Message{
 				MessageID: "response-msg",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("I received your weather question and here's the answer..."),
 				},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -352,15 +352,12 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 		ID:        "test-task",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: types.TaskStateCompleted,
+			State: string(types.TaskStateCompleted),
 			Message: &types.Message{
 				MessageID: "response-msg",
 				Role:      "assistant",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "Hello! I received your message.",
-					},
+					types.CreateTextPart("Hello! I received your message."),
 				},
 			},
 		},
@@ -390,10 +387,7 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 		MessageID: "original-msg",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "What is the weather like today?",
-			},
+			types.CreateTextPart("What is the weather like today?"),
 		},
 	}
 
@@ -434,15 +428,12 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 		ID:        "test-task",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: types.TaskStateCompleted,
+			State: string(types.TaskStateCompleted),
 			Message: &types.Message{
 				MessageID: "response-msg",
 				Role:      "assistant",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "I received your weather question and here's the answer...",
-					},
+					types.CreateTextPart("I received your weather question and here's the answer..."),
 				},
 			},
 		},
@@ -472,10 +463,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 		MessageID: "user-msg-123",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "What is the weather like today in San Francisco?",
-			},
+			types.CreateTextPart("What is the weather like today in San Francisco?"),
 		},
 	}
 
@@ -483,7 +471,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 		ID:        "task-456",
 		ContextID: "context-789",
 		Status: types.TaskStatus{
-			State:   types.TaskStateSubmitted,
+			State:   string(types.TaskStateSubmitted),
 			Message: originalUserMessage,
 		},
 		History: []types.Message{},
@@ -500,7 +488,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, types.TaskStateCompleted, result.Status.State)
+	assert.Equal(t, string(types.TaskStateCompleted), result.Status.State)
 
 	assert.Equal(t, 1, mockTaskHandler.HandleTaskCallCount())
 
@@ -513,10 +501,8 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 	assert.Len(t, actualMessage.Parts, 1, "Should have exactly one message part")
 
 	part := actualMessage.Parts[0]
-	partMap, ok := part.(map[string]any)
-	assert.True(t, ok, "Message part should be a map")
-	assert.Equal(t, "text", partMap["kind"], "Message part should be of kind 'text'")
-	assert.Equal(t, "What is the weather like today in San Francisco?", partMap["text"],
+	assert.NotNil(t, part.Text, "Message part should have text")
+	assert.Equal(t, "What is the weather like today in San Francisco?", *part.Text,
 		"Message content should be preserved exactly as sent by the client")
 
 	assert.Equal(t, "user", actualMessage.Role, "Message role should be 'user'")
@@ -659,10 +645,7 @@ func TestAgentStreamingIntegration_SimpleResponse(t *testing.T) {
 		{
 			Role: "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Say hello",
-				},
+				types.CreateTextPart("Say hello"),
 			},
 		},
 	}
@@ -718,17 +701,14 @@ func TestBackgroundHandler_WithStreamingAgent(t *testing.T) {
 		ContextID: "test-context",
 		History:   []types.Message{},
 		Status: types.TaskStatus{
-			State: types.TaskStateSubmitted,
+			State: string(types.TaskStateSubmitted),
 		},
 	}
 
 	message := &types.Message{
 		Role: "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Complete this task",
-			},
+			types.CreateTextPart("Complete this task"),
 		},
 	}
 
@@ -736,7 +716,7 @@ func TestBackgroundHandler_WithStreamingAgent(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, types.TaskStateCompleted, result.Status.State)
+	assert.Equal(t, string(types.TaskStateCompleted), result.Status.State)
 	assert.NotNil(t, result.Status.Message)
 }
 
@@ -769,17 +749,14 @@ func TestBackgroundHandler_StreamingFailure(t *testing.T) {
 		ContextID: "test-context",
 		History:   []types.Message{},
 		Status: types.TaskStatus{
-			State: types.TaskStateSubmitted,
+			State: string(types.TaskStateSubmitted),
 		},
 	}
 
 	message := &types.Message{
 		Role: "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "This will fail",
-			},
+			types.CreateTextPart("This will fail"),
 		},
 	}
 
@@ -787,7 +764,7 @@ func TestBackgroundHandler_StreamingFailure(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, types.TaskStateFailed, result.Status.State)
+	assert.Equal(t, string(types.TaskStateFailed), result.Status.State)
 }
 
 func TestAgentStreaming_WithToolCalls(t *testing.T) {
@@ -862,10 +839,7 @@ func TestAgentStreaming_WithToolCalls(t *testing.T) {
 		{
 			Role: "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Use the tool",
-				},
+				types.CreateTextPart("Use the tool"),
 			},
 		},
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -333,7 +333,7 @@ func TestA2AServerBuilder_HandlesNilConfigurationSafely(t *testing.T) {
 	assert.NotNil(t, agentCard)
 	assert.Equal(t, "test-agent", agentCard.Name)
 	assert.Equal(t, "A test agent", agentCard.Description)
-	assert.Equal(t, "http://test-agent:8080", agentCard.URL)
+	assert.Equal(t, "http://test-agent:8080", *agentCard.URL)
 	assert.Equal(t, "0.1.0", agentCard.Version)
 
 	assert.NotNil(t, agentCard.Capabilities.Streaming)
@@ -352,7 +352,7 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 		ID:        "test-task",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: string(types.TaskStateCompleted),
+			State: types.TaskStateCompleted,
 			Message: &types.Message{
 				MessageID: "response-msg",
 				Role:      "assistant",
@@ -395,7 +395,7 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 		ID:        "test-task",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State:   string(types.TaskStateSubmitted),
+			State:   types.TaskStateSubmitted,
 			Message: originalMessage,
 		},
 	}
@@ -405,7 +405,7 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, string(types.TaskStateCompleted), result.Status.State)
+	assert.Equal(t, types.TaskStateCompleted, result.Status.State)
 	assert.Equal(t, 1, mockTaskHandler.HandleTaskCallCount())
 
 	_, actualTask, actualMessage := mockTaskHandler.HandleTaskArgsForCall(0)
@@ -428,7 +428,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 		ID:        "test-task",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: string(types.TaskStateCompleted),
+			State: types.TaskStateCompleted,
 			Message: &types.Message{
 				MessageID: "response-msg",
 				Role:      "assistant",
@@ -471,7 +471,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 		ID:        "task-456",
 		ContextID: "context-789",
 		Status: types.TaskStatus{
-			State:   string(types.TaskStateSubmitted),
+			State:   types.TaskStateSubmitted,
 			Message: originalUserMessage,
 		},
 		History: []types.Message{},
@@ -488,7 +488,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, string(types.TaskStateCompleted), result.Status.State)
+	assert.Equal(t, types.TaskStateCompleted, result.Status.State)
 
 	assert.Equal(t, 1, mockTaskHandler.HandleTaskCallCount())
 
@@ -505,7 +505,7 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 	assert.Equal(t, "What is the weather like today in San Francisco?", *part.Text,
 		"Message content should be preserved exactly as sent by the client")
 
-	assert.Equal(t, "user", actualMessage.Role, "Message role should be 'user'")
+	assert.Equal(t, types.Role("user"), actualMessage.Role, "Message role should be user")
 }
 
 func TestTaskGetWithInvalidFieldName(t *testing.T) {
@@ -701,7 +701,7 @@ func TestBackgroundHandler_WithStreamingAgent(t *testing.T) {
 		ContextID: "test-context",
 		History:   []types.Message{},
 		Status: types.TaskStatus{
-			State: string(types.TaskStateSubmitted),
+			State: types.TaskStateSubmitted,
 		},
 	}
 
@@ -716,7 +716,7 @@ func TestBackgroundHandler_WithStreamingAgent(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, string(types.TaskStateCompleted), result.Status.State)
+	assert.Equal(t, types.TaskStateCompleted, result.Status.State)
 	assert.NotNil(t, result.Status.Message)
 }
 
@@ -749,7 +749,7 @@ func TestBackgroundHandler_StreamingFailure(t *testing.T) {
 		ContextID: "test-context",
 		History:   []types.Message{},
 		Status: types.TaskStatus{
-			State: string(types.TaskStateSubmitted),
+			State: types.TaskStateSubmitted,
 		},
 	}
 
@@ -764,7 +764,7 @@ func TestBackgroundHandler_StreamingFailure(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, string(types.TaskStateFailed), result.Status.State)
+	assert.Equal(t, types.TaskStateFailed, result.Status.State)
 }
 
 func TestAgentStreaming_WithToolCalls(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -52,7 +52,6 @@ func TestA2AServer_TaskManager_CreateTask(t *testing.T) {
 			contextID: "test-context-1",
 			state:     types.TaskStateSubmitted,
 			message: &types.Message{
-				Kind:      "message",
 				MessageID: "test-message-1",
 				Role:      "user",
 				Parts: []types.Part{
@@ -68,7 +67,6 @@ func TestA2AServer_TaskManager_CreateTask(t *testing.T) {
 			contextID: "test-context-2",
 			state:     types.TaskStateWorking,
 			message: &types.Message{
-				Kind:      "message",
 				MessageID: "test-message-2",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -103,7 +101,6 @@ func TestA2AServer_TaskManager_GetTask(t *testing.T) {
 	taskManager := server.NewDefaultTaskManager(logger)
 
 	message := &types.Message{
-		Kind:      "message",
 		MessageID: "test-message",
 		Role:      "user",
 	}
@@ -368,7 +365,6 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 		Status: types.TaskStatus{
 			State: types.TaskStateCompleted,
 			Message: &types.Message{
-				Kind:      "message",
 				MessageID: "response-msg",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -402,7 +398,6 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 	serverInstance.SetStreamingTaskHandler(&mocks.FakeStreamableTaskHandler{})
 
 	originalMessage := &types.Message{
-		Kind:      "message",
 		MessageID: "original-msg",
 		Role:      "user",
 		Parts: []types.Part{
@@ -416,7 +411,6 @@ func TestA2AServer_TaskProcessing_MessageContent(t *testing.T) {
 	task := &types.Task{
 		ID:        "test-task",
 		ContextID: "test-context",
-		Kind:      "task",
 		Status: types.TaskStatus{
 			State:   types.TaskStateSubmitted,
 			Message: originalMessage,
@@ -455,7 +449,6 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 		Status: types.TaskStatus{
 			State: types.TaskStateCompleted,
 			Message: &types.Message{
-				Kind:      "message",
 				MessageID: "response-msg",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -489,7 +482,6 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 	serverInstance.SetStreamingTaskHandler(&mocks.FakeStreamableTaskHandler{})
 
 	originalUserMessage := &types.Message{
-		Kind:      "message",
 		MessageID: "user-msg-123",
 		Role:      "user",
 		Parts: []types.Part{
@@ -503,7 +495,6 @@ func TestA2AServer_ProcessQueuedTask_MessageContent(t *testing.T) {
 	task := &types.Task{
 		ID:        "task-456",
 		ContextID: "context-789",
-		Kind:      "task",
 		Status: types.TaskStatus{
 			State:   types.TaskStateSubmitted,
 			Message: originalUserMessage,

--- a/server/storage_extensibility_test.go
+++ b/server/storage_extensibility_test.go
@@ -26,7 +26,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-1",
 					ContextID: testCtx,
 					Status: types.TaskStatus{
-						State: string(types.TaskStateSubmitted),
+						State: types.TaskStateSubmitted,
 					},
 				}
 
@@ -53,7 +53,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-2",
 					ContextID: testCtx,
 					Status: types.TaskStatus{
-						State: string(types.TaskStateCompleted),
+						State: types.TaskStateCompleted,
 					},
 				}
 
@@ -78,7 +78,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-3",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: string(types.TaskStateSubmitted),
+						State: types.TaskStateSubmitted,
 					},
 				}
 
@@ -109,7 +109,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-4",
 					ContextID: "test-context-length",
 					Status: types.TaskStatus{
-						State: string(types.TaskStateSubmitted),
+						State: types.TaskStateSubmitted,
 					},
 				}
 
@@ -131,14 +131,14 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-5",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: string(types.TaskStateCompleted),
+						State: types.TaskStateCompleted,
 					},
 				}
 				task2 := &types.Task{
 					ID:        "task-6",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: string(types.TaskStateCompleted),
+						State: types.TaskStateCompleted,
 					},
 				}
 
@@ -168,7 +168,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "active-task",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: string(types.TaskStateSubmitted),
+						State: types.TaskStateSubmitted,
 					},
 				}
 				err := storage.EnqueueTask(activeTask, "request-active")
@@ -180,7 +180,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "dead-task",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: string(types.TaskStateCompleted),
+						State: types.TaskStateCompleted,
 					},
 				}
 				err = storage.StoreDeadLetterTask(deadTask)

--- a/server/storage_extensibility_test.go
+++ b/server/storage_extensibility_test.go
@@ -26,7 +26,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-1",
 					ContextID: testCtx,
 					Status: types.TaskStatus{
-						State: types.TaskStateSubmitted,
+						State: string(types.TaskStateSubmitted),
 					},
 				}
 
@@ -53,7 +53,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-2",
 					ContextID: testCtx,
 					Status: types.TaskStatus{
-						State: types.TaskStateCompleted,
+						State: string(types.TaskStateCompleted),
 					},
 				}
 
@@ -78,7 +78,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-3",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: types.TaskStateSubmitted,
+						State: string(types.TaskStateSubmitted),
 					},
 				}
 
@@ -109,7 +109,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-4",
 					ContextID: "test-context-length",
 					Status: types.TaskStatus{
-						State: types.TaskStateSubmitted,
+						State: string(types.TaskStateSubmitted),
 					},
 				}
 
@@ -131,14 +131,14 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "task-5",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: types.TaskStateCompleted,
+						State: string(types.TaskStateCompleted),
 					},
 				}
 				task2 := &types.Task{
 					ID:        "task-6",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: types.TaskStateCompleted,
+						State: string(types.TaskStateCompleted),
 					},
 				}
 
@@ -168,7 +168,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "active-task",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: types.TaskStateSubmitted,
+						State: string(types.TaskStateSubmitted),
 					},
 				}
 				err := storage.EnqueueTask(activeTask, "request-active")
@@ -180,7 +180,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					ID:        "dead-task",
 					ContextID: testContext,
 					Status: types.TaskStatus{
-						State: types.TaskStateCompleted,
+						State: string(types.TaskStateCompleted),
 					},
 				}
 				err = storage.StoreDeadLetterTask(deadTask)

--- a/server/storage_extensibility_test.go
+++ b/server/storage_extensibility_test.go
@@ -25,7 +25,6 @@ func TestQueueCentricOperations(t *testing.T) {
 				task := &types.Task{
 					ID:        "task-1",
 					ContextID: testCtx,
-					Kind:      "task",
 					Status: types.TaskStatus{
 						State: types.TaskStateSubmitted,
 					},
@@ -53,7 +52,6 @@ func TestQueueCentricOperations(t *testing.T) {
 				task := &types.Task{
 					ID:        "task-2",
 					ContextID: testCtx,
-					Kind:      "task",
 					Status: types.TaskStatus{
 						State: types.TaskStateCompleted,
 					},
@@ -79,7 +77,6 @@ func TestQueueCentricOperations(t *testing.T) {
 				task := &types.Task{
 					ID:        "task-3",
 					ContextID: testContext,
-					Kind:      "task",
 					Status: types.TaskStatus{
 						State: types.TaskStateSubmitted,
 					},
@@ -111,7 +108,6 @@ func TestQueueCentricOperations(t *testing.T) {
 				task := &types.Task{
 					ID:        "task-4",
 					ContextID: "test-context-length",
-					Kind:      "task",
 					Status: types.TaskStatus{
 						State: types.TaskStateSubmitted,
 					},
@@ -134,7 +130,6 @@ func TestQueueCentricOperations(t *testing.T) {
 				task1 := &types.Task{
 					ID:        "task-5",
 					ContextID: testContext,
-					Kind:      "task",
 					Status: types.TaskStatus{
 						State: types.TaskStateCompleted,
 					},
@@ -142,7 +137,6 @@ func TestQueueCentricOperations(t *testing.T) {
 				task2 := &types.Task{
 					ID:        "task-6",
 					ContextID: testContext,
-					Kind:      "task",
 					Status: types.TaskStatus{
 						State: types.TaskStateCompleted,
 					},
@@ -173,7 +167,6 @@ func TestQueueCentricOperations(t *testing.T) {
 				activeTask := &types.Task{
 					ID:        "active-task",
 					ContextID: testContext,
-					Kind:      "task",
 					Status: types.TaskStatus{
 						State: types.TaskStateSubmitted,
 					},
@@ -186,7 +179,6 @@ func TestQueueCentricOperations(t *testing.T) {
 				deadTask := &types.Task{
 					ID:        "dead-task",
 					ContextID: testContext,
-					Kind:      "task",
 					Status: types.TaskStatus{
 						State: types.TaskStateCompleted,
 					},

--- a/server/storage_queue_test.go
+++ b/server/storage_queue_test.go
@@ -163,7 +163,6 @@ func TestInMemoryStorage_ConcurrentQueueOperations(t *testing.T) {
 					task := &types.Task{
 						ID:        fmt.Sprintf("task-%d-%d", i, j),
 						ContextID: "concurrent-test",
-						Kind:      "task",
 						Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 					}
 					err := storage.EnqueueTask(task, fmt.Sprintf("req-%d-%d", i, j))

--- a/server/storage_queue_test.go
+++ b/server/storage_queue_test.go
@@ -19,7 +19,7 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 		ID:        "test-task-1",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: string(types.TaskStateSubmitted),
+			State: types.TaskStateSubmitted,
 		},
 	}
 
@@ -55,9 +55,9 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 	})
 
 	t.Run("FIFO Ordering", func(t *testing.T) {
-		task1 := &types.Task{ID: "task-1", ContextID: "ctx-1", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
-		task2 := &types.Task{ID: "task-2", ContextID: "ctx-2", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
-		task3 := &types.Task{ID: "task-3", ContextID: "ctx-3", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
+		task1 := &types.Task{ID: "task-1", ContextID: "ctx-1", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
+		task2 := &types.Task{ID: "task-2", ContextID: "ctx-2", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
+		task3 := &types.Task{ID: "task-3", ContextID: "ctx-3", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
 
 		err := storage.EnqueueTask(task1, "req-1")
 		require.NoError(t, err)
@@ -105,8 +105,8 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 	})
 
 	t.Run("Clear Queue", func(t *testing.T) {
-		task1 := &types.Task{ID: "clear-task-1", ContextID: "ctx", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
-		task2 := &types.Task{ID: "clear-task-2", ContextID: "ctx", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
+		task1 := &types.Task{ID: "clear-task-1", ContextID: "ctx", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
+		task2 := &types.Task{ID: "clear-task-2", ContextID: "ctx", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
 
 		err := storage.EnqueueTask(task1, "req-1")
 		require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestInMemoryStorage_ConcurrentQueueOperations(t *testing.T) {
 					task := &types.Task{
 						ID:        fmt.Sprintf("task-%d-%d", i, j),
 						ContextID: "concurrent-test",
-						Status:    types.TaskStatus{State: string(types.TaskStateSubmitted)},
+						Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 					}
 					err := storage.EnqueueTask(task, fmt.Sprintf("req-%d-%d", i, j))
 					if err != nil {

--- a/server/storage_queue_test.go
+++ b/server/storage_queue_test.go
@@ -19,7 +19,7 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 		ID:        "test-task-1",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: types.TaskStateSubmitted,
+			State: string(types.TaskStateSubmitted),
 		},
 	}
 
@@ -55,9 +55,9 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 	})
 
 	t.Run("FIFO Ordering", func(t *testing.T) {
-		task1 := &types.Task{ID: "task-1", ContextID: "ctx-1", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
-		task2 := &types.Task{ID: "task-2", ContextID: "ctx-2", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
-		task3 := &types.Task{ID: "task-3", ContextID: "ctx-3", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
+		task1 := &types.Task{ID: "task-1", ContextID: "ctx-1", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
+		task2 := &types.Task{ID: "task-2", ContextID: "ctx-2", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
+		task3 := &types.Task{ID: "task-3", ContextID: "ctx-3", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
 
 		err := storage.EnqueueTask(task1, "req-1")
 		require.NoError(t, err)
@@ -105,8 +105,8 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 	})
 
 	t.Run("Clear Queue", func(t *testing.T) {
-		task1 := &types.Task{ID: "clear-task-1", ContextID: "ctx", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
-		task2 := &types.Task{ID: "clear-task-2", ContextID: "ctx", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
+		task1 := &types.Task{ID: "clear-task-1", ContextID: "ctx", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
+		task2 := &types.Task{ID: "clear-task-2", ContextID: "ctx", Status: types.TaskStatus{State: string(types.TaskStateSubmitted)}}
 
 		err := storage.EnqueueTask(task1, "req-1")
 		require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestInMemoryStorage_ConcurrentQueueOperations(t *testing.T) {
 					task := &types.Task{
 						ID:        fmt.Sprintf("task-%d-%d", i, j),
 						ContextID: "concurrent-test",
-						Status:    types.TaskStatus{State: types.TaskStateSubmitted},
+						Status:    types.TaskStatus{State: string(types.TaskStateSubmitted)},
 					}
 					err := storage.EnqueueTask(task, fmt.Sprintf("req-%d-%d", i, j))
 					if err != nil {

--- a/server/storage_redis_test.go
+++ b/server/storage_redis_test.go
@@ -161,7 +161,6 @@ func TestRedisStorageBasicOperations(t *testing.T) {
 	task := &types.Task{
 		ID:        "test-task-1",
 		ContextID: "test-context",
-		Kind:      "task",
 		Status: types.TaskStatus{
 			State: types.TaskStateSubmitted,
 		},
@@ -202,7 +201,6 @@ func TestRedisStorageActiveTaskOperations(t *testing.T) {
 	task := &types.Task{
 		ID:        "test-task-2",
 		ContextID: "test-context",
-		Kind:      "task",
 		Status: types.TaskStatus{
 			State: types.TaskStateSubmitted,
 		},
@@ -252,14 +250,12 @@ func TestRedisStorageDeadLetterOperations(t *testing.T) {
 	task := &types.Task{
 		ID:        "test-task-3",
 		ContextID: "test-context",
-		Kind:      "task",
 		Status: types.TaskStatus{
 			State: types.TaskStateCompleted,
 		},
 		History: []types.Message{
 			{
 				Role:      "user",
-				Kind:      "message",
 				MessageID: "msg-1",
 				Parts: []types.Part{
 					map[string]any{
@@ -314,23 +310,20 @@ func TestRedisStorageListOperations(t *testing.T) {
 		{
 			ID:        "task-1",
 			ContextID: "context-1",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateCompleted},
-			History:   []types.Message{{Role: "user", Kind: "message", MessageID: "msg1", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg1"}}}},
+			History:   []types.Message{{Role: "user", MessageID: "msg1", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg1"}}}},
 		},
 		{
 			ID:        "task-2",
 			ContextID: "context-1",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateFailed},
-			History:   []types.Message{{Role: "user", Kind: "message", MessageID: "msg2", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg2"}}}},
+			History:   []types.Message{{Role: "user", MessageID: "msg2", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg2"}}}},
 		},
 		{
 			ID:        "task-3",
 			ContextID: "context-2",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateCompleted},
-			History:   []types.Message{{Role: "user", Kind: "message", MessageID: "msg3", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg3"}}}},
+			History:   []types.Message{{Role: "user", MessageID: "msg3", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg3"}}}},
 		},
 	}
 
@@ -388,13 +381,11 @@ func TestRedisStorageContextOperations(t *testing.T) {
 	task1 := &types.Task{
 		ID:        "task-1",
 		ContextID: "context-1",
-		Kind:      "task",
 		Status:    types.TaskStatus{State: types.TaskStateCompleted},
 	}
 	task2 := &types.Task{
 		ID:        "task-2",
 		ContextID: "context-2",
-		Kind:      "task",
 		Status:    types.TaskStatus{State: types.TaskStateCompleted},
 	}
 
@@ -443,7 +434,6 @@ func TestRedisStorageClearQueue(t *testing.T) {
 	task := &types.Task{
 		ID:        "test-task",
 		ContextID: "test-context",
-		Kind:      "task",
 		Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 	}
 
@@ -474,16 +464,14 @@ func TestRedisStorageGetStats(t *testing.T) {
 	completedTask := &types.Task{
 		ID:        "completed-task",
 		ContextID: "context-1",
-		Kind:      "task",
 		Status:    types.TaskStatus{State: types.TaskStateCompleted},
-		History:   []types.Message{{Role: "user", Kind: "message", MessageID: "msg1", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg1"}}}},
+		History:   []types.Message{{Role: "user", MessageID: "msg1", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg1"}}}},
 	}
 	failedTask := &types.Task{
 		ID:        "failed-task",
 		ContextID: "context-2",
-		Kind:      "task",
 		Status:    types.TaskStatus{State: types.TaskStateFailed},
-		History:   []types.Message{{Role: "user", Kind: "message", MessageID: "msg2", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg2"}}}},
+		History:   []types.Message{{Role: "user", MessageID: "msg2", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg2"}}}},
 	}
 
 	err = storage.StoreDeadLetterTask(completedTask)

--- a/server/storage_redis_test.go
+++ b/server/storage_redis_test.go
@@ -162,7 +162,7 @@ func TestRedisStorageBasicOperations(t *testing.T) {
 		ID:        "test-task-1",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: string(types.TaskStateSubmitted),
+			State: types.TaskStateSubmitted,
 		},
 		History: []types.Message{},
 	}
@@ -202,7 +202,7 @@ func TestRedisStorageActiveTaskOperations(t *testing.T) {
 		ID:        "test-task-2",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: string(types.TaskStateSubmitted),
+			State: types.TaskStateSubmitted,
 		},
 		History: []types.Message{},
 	}
@@ -215,7 +215,7 @@ func TestRedisStorageActiveTaskOperations(t *testing.T) {
 	assert.Equal(t, task.ID, retrieved.ID)
 	assert.Equal(t, task.ContextID, retrieved.ContextID)
 
-	task.Status.State = string(types.TaskStateWorking)
+	task.Status.State = types.TaskStateWorking
 	err = storage.UpdateActiveTask(task)
 	require.NoError(t, err)
 
@@ -251,7 +251,7 @@ func TestRedisStorageDeadLetterOperations(t *testing.T) {
 		ID:        "test-task-3",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: string(types.TaskStateCompleted),
+			State: types.TaskStateCompleted,
 		},
 		History: []types.Message{
 			{
@@ -307,19 +307,19 @@ func TestRedisStorageListOperations(t *testing.T) {
 		{
 			ID:        "task-1",
 			ContextID: "context-1",
-			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+			Status:    types.TaskStatus{State: types.TaskStateCompleted},
 			History:   []types.Message{{Role: "user", MessageID: "msg1", Parts: []types.Part{types.CreateTextPart("msg1")}}},
 		},
 		{
 			ID:        "task-2",
 			ContextID: "context-1",
-			Status:    types.TaskStatus{State: string(types.TaskStateFailed)},
+			Status:    types.TaskStatus{State: types.TaskStateFailed},
 			History:   []types.Message{{Role: "user", MessageID: "msg2", Parts: []types.Part{types.CreateTextPart("msg2")}}},
 		},
 		{
 			ID:        "task-3",
 			ContextID: "context-2",
-			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+			Status:    types.TaskStatus{State: types.TaskStateCompleted},
 			History:   []types.Message{{Role: "user", MessageID: "msg3", Parts: []types.Part{types.CreateTextPart("msg3")}}},
 		},
 	}
@@ -378,12 +378,12 @@ func TestRedisStorageContextOperations(t *testing.T) {
 	task1 := &types.Task{
 		ID:        "task-1",
 		ContextID: "context-1",
-		Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+		Status:    types.TaskStatus{State: types.TaskStateCompleted},
 	}
 	task2 := &types.Task{
 		ID:        "task-2",
 		ContextID: "context-2",
-		Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+		Status:    types.TaskStatus{State: types.TaskStateCompleted},
 	}
 
 	err = storage.StoreDeadLetterTask(task1)
@@ -431,7 +431,7 @@ func TestRedisStorageClearQueue(t *testing.T) {
 	task := &types.Task{
 		ID:        "test-task",
 		ContextID: "test-context",
-		Status:    types.TaskStatus{State: string(types.TaskStateSubmitted)},
+		Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 	}
 
 	err = storage.EnqueueTask(task, "request-1")
@@ -461,13 +461,13 @@ func TestRedisStorageGetStats(t *testing.T) {
 	completedTask := &types.Task{
 		ID:        "completed-task",
 		ContextID: "context-1",
-		Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+		Status:    types.TaskStatus{State: types.TaskStateCompleted},
 		History:   []types.Message{{Role: "user", MessageID: "msg1", Parts: []types.Part{types.CreateTextPart("msg1")}}},
 	}
 	failedTask := &types.Task{
 		ID:        "failed-task",
 		ContextID: "context-2",
-		Status:    types.TaskStatus{State: string(types.TaskStateFailed)},
+		Status:    types.TaskStatus{State: types.TaskStateFailed},
 		History:   []types.Message{{Role: "user", MessageID: "msg2", Parts: []types.Part{types.CreateTextPart("msg2")}}},
 	}
 

--- a/server/storage_redis_test.go
+++ b/server/storage_redis_test.go
@@ -162,7 +162,7 @@ func TestRedisStorageBasicOperations(t *testing.T) {
 		ID:        "test-task-1",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: types.TaskStateSubmitted,
+			State: string(types.TaskStateSubmitted),
 		},
 		History: []types.Message{},
 	}
@@ -202,7 +202,7 @@ func TestRedisStorageActiveTaskOperations(t *testing.T) {
 		ID:        "test-task-2",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: types.TaskStateSubmitted,
+			State: string(types.TaskStateSubmitted),
 		},
 		History: []types.Message{},
 	}
@@ -215,7 +215,7 @@ func TestRedisStorageActiveTaskOperations(t *testing.T) {
 	assert.Equal(t, task.ID, retrieved.ID)
 	assert.Equal(t, task.ContextID, retrieved.ContextID)
 
-	task.Status.State = types.TaskStateWorking
+	task.Status.State = string(types.TaskStateWorking)
 	err = storage.UpdateActiveTask(task)
 	require.NoError(t, err)
 
@@ -251,17 +251,14 @@ func TestRedisStorageDeadLetterOperations(t *testing.T) {
 		ID:        "test-task-3",
 		ContextID: "test-context",
 		Status: types.TaskStatus{
-			State: types.TaskStateCompleted,
+			State: string(types.TaskStateCompleted),
 		},
 		History: []types.Message{
 			{
 				Role:      "user",
 				MessageID: "msg-1",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "test message",
-					},
+					types.CreateTextPart("test message"),
 				},
 			},
 		},
@@ -310,20 +307,20 @@ func TestRedisStorageListOperations(t *testing.T) {
 		{
 			ID:        "task-1",
 			ContextID: "context-1",
-			Status:    types.TaskStatus{State: types.TaskStateCompleted},
-			History:   []types.Message{{Role: "user", MessageID: "msg1", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg1"}}}},
+			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+			History:   []types.Message{{Role: "user", MessageID: "msg1", Parts: []types.Part{types.CreateTextPart("msg1")}}},
 		},
 		{
 			ID:        "task-2",
 			ContextID: "context-1",
-			Status:    types.TaskStatus{State: types.TaskStateFailed},
-			History:   []types.Message{{Role: "user", MessageID: "msg2", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg2"}}}},
+			Status:    types.TaskStatus{State: string(types.TaskStateFailed)},
+			History:   []types.Message{{Role: "user", MessageID: "msg2", Parts: []types.Part{types.CreateTextPart("msg2")}}},
 		},
 		{
 			ID:        "task-3",
 			ContextID: "context-2",
-			Status:    types.TaskStatus{State: types.TaskStateCompleted},
-			History:   []types.Message{{Role: "user", MessageID: "msg3", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg3"}}}},
+			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+			History:   []types.Message{{Role: "user", MessageID: "msg3", Parts: []types.Part{types.CreateTextPart("msg3")}}},
 		},
 	}
 
@@ -381,12 +378,12 @@ func TestRedisStorageContextOperations(t *testing.T) {
 	task1 := &types.Task{
 		ID:        "task-1",
 		ContextID: "context-1",
-		Status:    types.TaskStatus{State: types.TaskStateCompleted},
+		Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
 	}
 	task2 := &types.Task{
 		ID:        "task-2",
 		ContextID: "context-2",
-		Status:    types.TaskStatus{State: types.TaskStateCompleted},
+		Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
 	}
 
 	err = storage.StoreDeadLetterTask(task1)
@@ -434,7 +431,7 @@ func TestRedisStorageClearQueue(t *testing.T) {
 	task := &types.Task{
 		ID:        "test-task",
 		ContextID: "test-context",
-		Status:    types.TaskStatus{State: types.TaskStateSubmitted},
+		Status:    types.TaskStatus{State: string(types.TaskStateSubmitted)},
 	}
 
 	err = storage.EnqueueTask(task, "request-1")
@@ -464,14 +461,14 @@ func TestRedisStorageGetStats(t *testing.T) {
 	completedTask := &types.Task{
 		ID:        "completed-task",
 		ContextID: "context-1",
-		Status:    types.TaskStatus{State: types.TaskStateCompleted},
-		History:   []types.Message{{Role: "user", MessageID: "msg1", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg1"}}}},
+		Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+		History:   []types.Message{{Role: "user", MessageID: "msg1", Parts: []types.Part{types.CreateTextPart("msg1")}}},
 	}
 	failedTask := &types.Task{
 		ID:        "failed-task",
 		ContextID: "context-2",
-		Status:    types.TaskStatus{State: types.TaskStateFailed},
-		History:   []types.Message{{Role: "user", MessageID: "msg2", Parts: []types.Part{map[string]any{"kind": "text", "text": "msg2"}}}},
+		Status:    types.TaskStatus{State: string(types.TaskStateFailed)},
+		History:   []types.Message{{Role: "user", MessageID: "msg2", Parts: []types.Part{types.CreateTextPart("msg2")}}},
 	}
 
 	err = storage.StoreDeadLetterTask(completedTask)

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -20,7 +20,6 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-1",
 			ContextID: "context-1",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 			History:   []types.Message{},
 		}
@@ -41,7 +40,6 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-2",
 			ContextID: "context-2",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateWorking},
 			History:   []types.Message{},
 		}
@@ -67,7 +65,6 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-3",
 			ContextID: "context-3",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateCompleted},
 			History:   []types.Message{},
 		}
@@ -89,7 +86,6 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		workingTask := &types.Task{
 			ID:        "working-task",
 			ContextID: "context-working",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateWorking},
 			History:   []types.Message{},
 		}
@@ -97,7 +93,6 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		completedTask := &types.Task{
 			ID:        "completed-task",
 			ContextID: "context-completed",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateCompleted},
 			History:   []types.Message{},
 		}
@@ -132,7 +127,6 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 			task := &types.Task{
 				ID:        fmt.Sprintf("queue-task-%d", i),
 				ContextID: fmt.Sprintf("context-%d", i),
-				Kind:      "task",
 				Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 				History:   []types.Message{},
 			}
@@ -163,7 +157,6 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task1 := &types.Task{
 			ID:        "ctx-task-1",
 			ContextID: "context-alpha",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateWorking},
 			History:   []types.Message{},
 		}
@@ -171,7 +164,6 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task2 := &types.Task{
 			ID:        "ctx-task-2",
 			ContextID: "context-beta",
-			Kind:      "task",
 			Status:    types.TaskStatus{State: types.TaskStateCompleted},
 			History:   []types.Message{},
 		}

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -20,7 +20,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-1",
 			ContextID: "context-1",
-			Status:    types.TaskStatus{State: types.TaskStateSubmitted},
+			Status:    types.TaskStatus{State: string(types.TaskStateSubmitted)},
 			History:   []types.Message{},
 		}
 
@@ -40,7 +40,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-2",
 			ContextID: "context-2",
-			Status:    types.TaskStatus{State: types.TaskStateWorking},
+			Status:    types.TaskStatus{State: string(types.TaskStateWorking)},
 			History:   []types.Message{},
 		}
 
@@ -51,13 +51,13 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "task-2", retrievedTask.ID)
 
-		task.Status.State = types.TaskStateInputRequired
+		task.Status.State = string(types.TaskStateInputRequired)
 		err = storage.UpdateActiveTask(task)
 		assert.NoError(t, err)
 
 		updatedTask, err := storage.GetActiveTask("task-2")
 		assert.NoError(t, err)
-		assert.Equal(t, types.TaskStateInputRequired, updatedTask.Status.State)
+		assert.Equal(t, string(types.TaskStateInputRequired), updatedTask.Status.State)
 	})
 
 	t.Run("dead letter queue functionality", func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-3",
 			ContextID: "context-3",
-			Status:    types.TaskStatus{State: types.TaskStateCompleted},
+			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
 			History:   []types.Message{},
 		}
 
@@ -78,7 +78,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		retrievedTask, found := storage.GetTask("task-3")
 		assert.True(t, found)
 		assert.Equal(t, "task-3", retrievedTask.ID)
-		assert.Equal(t, types.TaskStateCompleted, retrievedTask.Status.State)
+		assert.Equal(t, string(types.TaskStateCompleted), retrievedTask.Status.State)
 	})
 
 	t.Run("list tasks with filtering", func(t *testing.T) {
@@ -86,14 +86,14 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		workingTask := &types.Task{
 			ID:        "working-task",
 			ContextID: "context-working",
-			Status:    types.TaskStatus{State: types.TaskStateWorking},
+			Status:    types.TaskStatus{State: string(types.TaskStateWorking)},
 			History:   []types.Message{},
 		}
 
 		completedTask := &types.Task{
 			ID:        "completed-task",
 			ContextID: "context-completed",
-			Status:    types.TaskStatus{State: types.TaskStateCompleted},
+			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
 			History:   []types.Message{},
 		}
 
@@ -127,7 +127,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 			task := &types.Task{
 				ID:        fmt.Sprintf("queue-task-%d", i),
 				ContextID: fmt.Sprintf("context-%d", i),
-				Status:    types.TaskStatus{State: types.TaskStateSubmitted},
+				Status:    types.TaskStatus{State: string(types.TaskStateSubmitted)},
 				History:   []types.Message{},
 			}
 
@@ -157,14 +157,14 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task1 := &types.Task{
 			ID:        "ctx-task-1",
 			ContextID: "context-alpha",
-			Status:    types.TaskStatus{State: types.TaskStateWorking},
+			Status:    types.TaskStatus{State: string(types.TaskStateWorking)},
 			History:   []types.Message{},
 		}
 
 		task2 := &types.Task{
 			ID:        "ctx-task-2",
 			ContextID: "context-beta",
-			Status:    types.TaskStatus{State: types.TaskStateCompleted},
+			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
 			History:   []types.Message{},
 		}
 

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -20,7 +20,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-1",
 			ContextID: "context-1",
-			Status:    types.TaskStatus{State: string(types.TaskStateSubmitted)},
+			Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 			History:   []types.Message{},
 		}
 
@@ -40,7 +40,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-2",
 			ContextID: "context-2",
-			Status:    types.TaskStatus{State: string(types.TaskStateWorking)},
+			Status:    types.TaskStatus{State: types.TaskStateWorking},
 			History:   []types.Message{},
 		}
 
@@ -51,13 +51,13 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "task-2", retrievedTask.ID)
 
-		task.Status.State = string(types.TaskStateInputRequired)
+		task.Status.State = types.TaskStateInputRequired
 		err = storage.UpdateActiveTask(task)
 		assert.NoError(t, err)
 
 		updatedTask, err := storage.GetActiveTask("task-2")
 		assert.NoError(t, err)
-		assert.Equal(t, string(types.TaskStateInputRequired), updatedTask.Status.State)
+		assert.Equal(t, types.TaskStateInputRequired, updatedTask.Status.State)
 	})
 
 	t.Run("dead letter queue functionality", func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task := &types.Task{
 			ID:        "task-3",
 			ContextID: "context-3",
-			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+			Status:    types.TaskStatus{State: types.TaskStateCompleted},
 			History:   []types.Message{},
 		}
 
@@ -78,7 +78,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		retrievedTask, found := storage.GetTask("task-3")
 		assert.True(t, found)
 		assert.Equal(t, "task-3", retrievedTask.ID)
-		assert.Equal(t, string(types.TaskStateCompleted), retrievedTask.Status.State)
+		assert.Equal(t, types.TaskStateCompleted, retrievedTask.Status.State)
 	})
 
 	t.Run("list tasks with filtering", func(t *testing.T) {
@@ -86,14 +86,14 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		workingTask := &types.Task{
 			ID:        "working-task",
 			ContextID: "context-working",
-			Status:    types.TaskStatus{State: string(types.TaskStateWorking)},
+			Status:    types.TaskStatus{State: types.TaskStateWorking},
 			History:   []types.Message{},
 		}
 
 		completedTask := &types.Task{
 			ID:        "completed-task",
 			ContextID: "context-completed",
-			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+			Status:    types.TaskStatus{State: types.TaskStateCompleted},
 			History:   []types.Message{},
 		}
 
@@ -127,7 +127,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 			task := &types.Task{
 				ID:        fmt.Sprintf("queue-task-%d", i),
 				ContextID: fmt.Sprintf("context-%d", i),
-				Status:    types.TaskStatus{State: string(types.TaskStateSubmitted)},
+				Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 				History:   []types.Message{},
 			}
 
@@ -157,14 +157,14 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 		task1 := &types.Task{
 			ID:        "ctx-task-1",
 			ContextID: "context-alpha",
-			Status:    types.TaskStatus{State: string(types.TaskStateWorking)},
+			Status:    types.TaskStatus{State: types.TaskStateWorking},
 			History:   []types.Message{},
 		}
 
 		task2 := &types.Task{
 			ID:        "ctx-task-2",
 			ContextID: "context-beta",
-			Status:    types.TaskStatus{State: string(types.TaskStateCompleted)},
+			Status:    types.TaskStatus{State: types.TaskStateCompleted},
 			History:   []types.Message{},
 		}
 

--- a/server/task_cancellation_test.go
+++ b/server/task_cancellation_test.go
@@ -39,10 +39,7 @@ func TestTaskCancellation(t *testing.T) {
 			MessageID: "test-message",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Test message",
-				},
+				types.CreateTextPart("Test message"),
 			},
 		})
 
@@ -94,10 +91,7 @@ func TestTaskCancellation(t *testing.T) {
 			MessageID: "test-message",
 			Role:      "assistant",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Task completed",
-				},
+				types.CreateTextPart("Task completed"),
 			},
 		})
 
@@ -111,10 +105,7 @@ func TestTaskCancellation(t *testing.T) {
 			MessageID: "test-message",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Test message",
-				},
+				types.CreateTextPart("Test message"),
 			},
 		})
 

--- a/server/task_cancellation_test.go
+++ b/server/task_cancellation_test.go
@@ -36,7 +36,6 @@ func TestTaskCancellation(t *testing.T) {
 
 	t.Run("CancelTaskActuallyCancelsContext", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateWorking, &types.Message{
-			Kind:      "message",
 			MessageID: "test-message",
 			Role:      "user",
 			Parts: []types.Part{
@@ -92,7 +91,6 @@ func TestTaskCancellation(t *testing.T) {
 
 	t.Run("CancelAlreadyCompletedTask", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateCompleted, &types.Message{
-			Kind:      "message",
 			MessageID: "test-message",
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -110,7 +108,6 @@ func TestTaskCancellation(t *testing.T) {
 
 	t.Run("CancelTaskWithoutRegisteredCancelFunc", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateWorking, &types.Message{
-			Kind:      "message",
 			MessageID: "test-message",
 			Role:      "user",
 			Parts: []types.Part{

--- a/server/task_cancellation_test.go
+++ b/server/task_cancellation_test.go
@@ -89,7 +89,7 @@ func TestTaskCancellation(t *testing.T) {
 	t.Run("CancelAlreadyCompletedTask", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateCompleted, &types.Message{
 			MessageID: "test-message",
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateTextPart("Task completed"),
 			},

--- a/server/task_cancellation_test.go
+++ b/server/task_cancellation_test.go
@@ -72,7 +72,7 @@ func TestTaskCancellation(t *testing.T) {
 
 		updatedTask, exists := taskManager.GetTask(task.ID)
 		assert.True(t, exists, "Task should exist")
-		assert.Equal(t, types.TaskStateCanceled, updatedTask.Status.State, "Task state should be cancelled")
+		assert.Equal(t, types.TaskStateCancelled, updatedTask.Status.State, "Task state should be cancelled")
 
 		taskManager.runningTasksMu.RLock()
 		_, exists = taskManager.runningTasks[task.ID]
@@ -114,6 +114,6 @@ func TestTaskCancellation(t *testing.T) {
 
 		updatedTask, exists := taskManager.GetTask(task.ID)
 		assert.True(t, exists, "Task should exist")
-		assert.Equal(t, types.TaskStateCanceled, updatedTask.Status.State, "Task state should be cancelled")
+		assert.Equal(t, types.TaskStateCancelled, updatedTask.Status.State, "Task state should be cancelled")
 	})
 }

--- a/server/task_handler.go
+++ b/server/task_handler.go
@@ -140,7 +140,6 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 
 		task.Status.State = types.TaskStateFailed
 		task.Status.Message = &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("error-%s", task.ID),
 			Role:      "assistant",
 			TaskID:    &task.ID,
@@ -235,7 +234,6 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 
 	task.Status.State = types.TaskStateCompleted
 	task.Status.Message = &types.Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("empty-response-%s", task.ID),
 		Role:      "assistant",
 		TaskID:    &task.ID,
@@ -257,7 +255,6 @@ func (bth *DefaultBackgroundTaskHandler) processWithoutAgentBackground(ctx conte
 		zap.String("task_id", task.ID))
 
 	response := &types.Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("response-%s", task.ID),
 		Role:      "assistant",
 		TaskID:    &task.ID,
@@ -462,7 +459,6 @@ func (h *DefaultA2AProtocolHandler) HandleMessageSend(c *gin.Context, req types.
 	if err != nil {
 		h.logger.Error("failed to enqueue task", zap.Error(err))
 		err := h.taskManager.UpdateError(task.ID, &types.Message{
-			Kind:      "message",
 			MessageID: uuid.New().String(),
 			Role:      "assistant",
 			TaskID:    &task.ID,
@@ -589,7 +585,6 @@ func (h *DefaultA2AProtocolHandler) HandleMessageStream(c *gin.Context, req type
 		message = task.Status.Message
 	} else {
 		message = &types.Message{
-			Kind:      "message",
 			MessageID: uuid.New().String(),
 			Role:      "user",
 			Parts:     []types.Part{},

--- a/server/task_handler.go
+++ b/server/task_handler.go
@@ -138,7 +138,7 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 	if err != nil {
 		bth.logger.Error("agent streaming failed to start", zap.Error(err))
 
-		task.Status.State = string(types.TaskStateFailed)
+		task.Status.State = types.TaskStateFailed
 		task.Status.Message = &types.Message{
 			MessageID: fmt.Sprintf("error-%s", task.ID),
 			Role:      "assistant",
@@ -172,9 +172,9 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 					zap.String("task_id", task.ID),
 					zap.String("state", string(statusData.State)))
 
-				if statusData.State == string(types.TaskStateCompleted) ||
-					statusData.State == string(types.TaskStateFailed) ||
-					statusData.State == string(types.TaskStateCanceled) {
+				if statusData.State == types.TaskStateCompleted ||
+					statusData.State == types.TaskStateFailed ||
+					statusData.State == types.TaskStateCancelled {
 					return task, nil
 				}
 			}
@@ -196,7 +196,7 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 				}
 				task.History = append(task.History, inputMessage)
 
-				task.Status.State = string(types.TaskStateInputRequired)
+				task.Status.State = types.TaskStateInputRequired
 				task.Status.Message = &inputMessage
 
 				bth.logger.Info("background task paused for user input",
@@ -217,7 +217,7 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 	}
 
 	if finalMessage != nil {
-		task.Status.State = string(types.TaskStateCompleted)
+		task.Status.State = types.TaskStateCompleted
 		task.Status.Message = finalMessage
 
 		bth.logger.Info("background task completed successfully",
@@ -229,7 +229,7 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 	bth.logger.Warn("background task completed but no final message received",
 		zap.String("task_id", task.ID))
 
-	task.Status.State = string(types.TaskStateCompleted)
+	task.Status.State = types.TaskStateCompleted
 	task.Status.Message = &types.Message{
 		MessageID: fmt.Sprintf("empty-response-%s", task.ID),
 		Role:      "assistant",
@@ -262,7 +262,7 @@ func (bth *DefaultBackgroundTaskHandler) processWithoutAgentBackground(ctx conte
 		task.History = []types.Message{}
 	}
 	task.History = append(task.History, *response)
-	task.Status.State = string(types.TaskStateCompleted)
+	task.Status.State = types.TaskStateCompleted
 	task.Status.Message = response
 
 	return task, nil
@@ -620,7 +620,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageStream(c *gin.Context, req type
 					zap.Int("total_length", len(accumulatedText)))
 
 				task.Status.Message = &deltaMessage
-				task.Status.State = string(types.TaskStateWorking)
+				task.Status.State = types.TaskStateWorking
 
 				deltaResponse := types.JSONRPCSuccessResponse{
 					JSONRPC: "2.0",
@@ -657,7 +657,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageStream(c *gin.Context, req type
 					TaskID:    task.ID,
 					ContextID: task.ContextID,
 					Status:    statusData,
-					Final:     statusData.State == string(types.TaskStateCompleted) || statusData.State == string(types.TaskStateFailed) || statusData.State == string(types.TaskStateCanceled),
+					Final:     statusData.State == types.TaskStateCompleted || statusData.State == types.TaskStateFailed || statusData.State == types.TaskStateCancelled,
 				}
 
 				statusResponse := types.JSONRPCSuccessResponse{
@@ -676,7 +676,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageStream(c *gin.Context, req type
 			var inputMessage types.Message
 			if err := event.DataAs(&inputMessage); err == nil {
 				task.History = append(task.History, inputMessage)
-				task.Status.State = string(types.TaskStateInputRequired)
+				task.Status.State = types.TaskStateInputRequired
 				task.Status.Message = &inputMessage
 
 				h.logger.Info("streaming task paused for user input",
@@ -687,7 +687,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageStream(c *gin.Context, req type
 					TaskID:    task.ID,
 					ContextID: task.ContextID,
 					Status: types.TaskStatus{
-						State:   string(types.TaskStateInputRequired),
+						State:   types.TaskStateInputRequired,
 						Message: &inputMessage,
 					},
 					Final: false,
@@ -716,7 +716,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageStream(c *gin.Context, req type
 			var interruptMessage types.Message
 			if err := event.DataAs(&interruptMessage); err == nil {
 				task.History = append(task.History, interruptMessage)
-				task.Status.State = string(types.TaskStateCanceled)
+				task.Status.State = types.TaskStateCancelled
 
 				h.logger.Info("streaming task was interrupted",
 					zap.String("task_id", task.ID),
@@ -734,7 +734,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageStream(c *gin.Context, req type
 			var errorMessage types.Message
 			if err := event.DataAs(&errorMessage); err == nil {
 				task.History = append(task.History, errorMessage)
-				task.Status.State = string(types.TaskStateFailed)
+				task.Status.State = types.TaskStateFailed
 				task.Status.Message = &errorMessage
 
 				h.logger.Error("streaming task failed",
@@ -763,7 +763,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageStream(c *gin.Context, req type
 	}
 
 	if len(task.History) > 0 {
-		task.Status.State = string(types.TaskStateCompleted)
+		task.Status.State = types.TaskStateCompleted
 		task.Status.Message = &task.History[len(task.History)-1]
 
 		if err := h.taskManager.UpdateTask(task); err != nil {

--- a/server/task_handler.go
+++ b/server/task_handler.go
@@ -141,7 +141,7 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 		task.Status.State = types.TaskStateFailed
 		task.Status.Message = &types.Message{
 			MessageID: fmt.Sprintf("error-%s", task.ID),
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			TaskID:    &task.ID,
 			ContextID: &task.ContextID,
 			Parts: []types.Part{
@@ -232,7 +232,7 @@ func (bth *DefaultBackgroundTaskHandler) processWithAgentBackground(ctx context.
 	task.Status.State = types.TaskStateCompleted
 	task.Status.Message = &types.Message{
 		MessageID: fmt.Sprintf("empty-response-%s", task.ID),
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		TaskID:    &task.ID,
 		ContextID: &task.ContextID,
 		Parts: []types.Part{
@@ -250,7 +250,7 @@ func (bth *DefaultBackgroundTaskHandler) processWithoutAgentBackground(ctx conte
 
 	response := &types.Message{
 		MessageID: fmt.Sprintf("response-%s", task.ID),
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		TaskID:    &task.ID,
 		ContextID: &task.ContextID,
 		Parts: []types.Part{
@@ -448,7 +448,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageSend(c *gin.Context, req types.
 		h.logger.Error("failed to enqueue task", zap.Error(err))
 		err := h.taskManager.UpdateError(task.ID, &types.Message{
 			MessageID: uuid.New().String(),
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			TaskID:    &task.ID,
 			ContextID: &task.ContextID,
 			Parts: []types.Part{

--- a/server/task_handler_test.go
+++ b/server/task_handler_test.go
@@ -27,7 +27,6 @@ func TestDefaultBackgroundTaskHandler_HandleTask(t *testing.T) {
 				Status: types.TaskStatus{
 					State: types.TaskStateSubmitted,
 					Message: &types.Message{
-						Kind:      "message",
 						MessageID: "test-msg",
 						Role:      "user",
 						Parts: []types.Part{
@@ -126,7 +125,6 @@ func TestDefaultBackgroundTaskHandler_InputPausing(t *testing.T) {
 				taskHandler.SetAgent(tt.agent)
 			}
 			message := &types.Message{
-				Kind: "message",
 				Role: "user",
 				Parts: []types.Part{
 					types.TextPart{
@@ -192,7 +190,6 @@ func TestDefaultStreamingTaskHandler_HandleStreamingTask(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			taskHandler := server.NewDefaultStreamingTaskHandler(logger, tt.agent)
 			message := &types.Message{
-				Kind: "message",
 				Role: "user",
 				Parts: []types.Part{
 					types.TextPart{
@@ -283,7 +280,6 @@ func TestDefaultA2AProtocolHandler_ContextHistoryHandling(t *testing.T) {
 			contextID: stringPtr("existing-context"),
 			existingHistory: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "msg-1",
 					Role:      "user",
 					Parts: []types.Part{
@@ -313,7 +309,6 @@ func TestDefaultA2AProtocolHandler_ContextHistoryHandling(t *testing.T) {
 			contextID: stringPtr("multi-history-context"),
 			existingHistory: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "msg-1",
 					Role:      "user",
 					Parts: []types.Part{
@@ -324,7 +319,6 @@ func TestDefaultA2AProtocolHandler_ContextHistoryHandling(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "msg-2",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -360,7 +354,6 @@ func TestDefaultA2AProtocolHandler_ContextHistoryHandling(t *testing.T) {
 			mockTaskManager.CreateTaskReturns(expectedTask)
 
 			testMessage := types.Message{
-				Kind:      "message",
 				MessageID: "test-msg",
 				Role:      "user",
 				ContextID: tt.contextID,

--- a/server/task_handler_test.go
+++ b/server/task_handler_test.go
@@ -30,10 +30,7 @@ func TestDefaultBackgroundTaskHandler_HandleTask(t *testing.T) {
 						MessageID: "test-msg",
 						Role:      "user",
 						Parts: []types.Part{
-							types.TextPart{
-								Kind: "text",
-								Text: "Hello from task",
-							},
+							types.CreateTextPart("Hello from task"),
 						},
 					},
 				},
@@ -74,7 +71,7 @@ func TestDefaultBackgroundTaskHandler_HandleTask(t *testing.T) {
 				assert.NotNil(t, result)
 				assert.Equal(t, types.TaskStateCompleted, result.Status.State)
 				assert.NotNil(t, result.Status.Message)
-				assert.Equal(t, "assistant", result.Status.Message.Role)
+				assert.Equal(t, types.Role("assistant"), result.Status.Message.Role)
 				assert.GreaterOrEqual(t, len(result.History), 1)
 			}
 		})
@@ -127,10 +124,7 @@ func TestDefaultBackgroundTaskHandler_InputPausing(t *testing.T) {
 			message := &types.Message{
 				Role: "user",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Test message",
-					},
+					types.CreateTextPart("Test message"),
 				},
 			}
 
@@ -192,10 +186,7 @@ func TestDefaultStreamingTaskHandler_HandleStreamingTask(t *testing.T) {
 			message := &types.Message{
 				Role: "user",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Test streaming message",
-					},
+					types.CreateTextPart("Test streaming message"),
 				},
 			}
 
@@ -279,10 +270,7 @@ func TestDefaultA2AProtocolHandler_ContextHistoryHandling(t *testing.T) {
 					MessageID: "msg-1",
 					Role:      "user",
 					Parts: []types.Part{
-						types.TextPart{
-							Kind: "text",
-							Text: "Previous message from conversation",
-						},
+						types.CreateTextPart("Previous message from conversation"),
 					},
 				},
 			},
@@ -308,20 +296,14 @@ func TestDefaultA2AProtocolHandler_ContextHistoryHandling(t *testing.T) {
 					MessageID: "msg-1",
 					Role:      "user",
 					Parts: []types.Part{
-						types.TextPart{
-							Kind: "text",
-							Text: "First message",
-						},
+						types.CreateTextPart("First message"),
 					},
 				},
 				{
 					MessageID: "msg-2",
 					Role:      "assistant",
 					Parts: []types.Part{
-						types.TextPart{
-							Kind: "text",
-							Text: "Assistant response",
-						},
+						types.CreateTextPart("Assistant response"),
 					},
 				},
 			},
@@ -354,10 +336,7 @@ func TestDefaultA2AProtocolHandler_ContextHistoryHandling(t *testing.T) {
 				Role:      "user",
 				ContextID: tt.contextID,
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Test message for context history",
-					},
+					types.CreateTextPart("Test message for context history"),
 				},
 			}
 
@@ -415,86 +394,40 @@ func TestDefaultA2AProtocolHandler_MessageEnrichment(t *testing.T) {
 	tests := []struct {
 		name              string
 		inputMessage      types.Message
-		expectedKind      string
 		expectedMessageID string
 		shouldGenerateID  bool
 	}{
 		{
-			name: "message without Kind and MessageID should be enriched",
+			name: "message without MessageID should be enriched",
 			inputMessage: types.Message{
 				Role: "user",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Hello without kind and messageId",
-					},
+					types.CreateTextPart("Hello without messageId"),
 				},
 			},
-			expectedKind:     "message",
 			shouldGenerateID: true,
 		},
 		{
-			name: "message with empty Kind and MessageID should be enriched",
+			name: "message with empty MessageID should be enriched",
 			inputMessage: types.Message{
-				Kind:      "",
 				MessageID: "",
 				Role:      "user",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Hello with empty kind and messageId",
-					},
+					types.CreateTextPart("Hello with empty messageId"),
 				},
 			},
-			expectedKind:     "message",
 			shouldGenerateID: true,
 		},
 		{
-			name: "message with existing Kind and MessageID should be preserved",
+			name: "message with existing MessageID should be preserved",
 			inputMessage: types.Message{
-				Kind:      "existing_kind",
 				MessageID: "existing_message_id",
 				Role:      "user",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Hello with existing kind and messageId",
-					},
+					types.CreateTextPart("Hello with existing messageId"),
 				},
 			},
-			expectedKind:      "existing_kind",
 			expectedMessageID: "existing_message_id",
-			shouldGenerateID:  false,
-		},
-		{
-			name: "message with only Kind should generate MessageID",
-			inputMessage: types.Message{
-				Kind: "custom_kind",
-				Role: "user",
-				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Hello with custom kind but no messageId",
-					},
-				},
-			},
-			expectedKind:     "custom_kind",
-			shouldGenerateID: true,
-		},
-		{
-			name: "message with only MessageID should get default Kind",
-			inputMessage: types.Message{
-				MessageID: "custom_message_id",
-				Role:      "user",
-				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Hello with custom messageId but no kind",
-					},
-				},
-			},
-			expectedKind:      "message",
-			expectedMessageID: "custom_message_id",
 			shouldGenerateID:  false,
 		},
 	}
@@ -538,8 +471,6 @@ func TestDefaultA2AProtocolHandler_MessageEnrichment(t *testing.T) {
 
 			assert.Equal(t, 1, mockTaskManager.CreateTaskCallCount())
 			_, _, enrichedMessage := mockTaskManager.CreateTaskArgsForCall(0)
-
-			assert.Equal(t, tt.expectedKind, enrichedMessage.Kind)
 
 			if tt.shouldGenerateID {
 				assert.NotEmpty(t, enrichedMessage.MessageID, "MessageID should be generated when missing")

--- a/server/task_handler_test.go
+++ b/server/task_handler_test.go
@@ -71,7 +71,7 @@ func TestDefaultBackgroundTaskHandler_HandleTask(t *testing.T) {
 				assert.NotNil(t, result)
 				assert.Equal(t, types.TaskStateCompleted, result.Status.State)
 				assert.NotNil(t, result.Status.Message)
-				assert.Equal(t, types.Role("assistant"), result.Status.Message.Role)
+				assert.Equal(t, types.RoleAgent, result.Status.Message.Role)
 				assert.GreaterOrEqual(t, len(result.History), 1)
 			}
 		})
@@ -229,7 +229,7 @@ func createMockAgentWithInputRequired() server.OpenAICompatibleAgent {
 
 	inputMessage := &types.Message{
 		MessageID: "stream-input-req-123",
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
 			types.CreateTextPart("I need more information from you to continue."),
 		},
@@ -301,7 +301,7 @@ func TestDefaultA2AProtocolHandler_ContextHistoryHandling(t *testing.T) {
 				},
 				{
 					MessageID: "msg-2",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Assistant response"),
 					},

--- a/server/task_handler_test.go
+++ b/server/task_handler_test.go
@@ -553,7 +553,3 @@ func TestDefaultA2AProtocolHandler_MessageEnrichment(t *testing.T) {
 		})
 	}
 }
-
-func stringPtr(s string) *string {
-	return &s
-}

--- a/server/task_handler_test.go
+++ b/server/task_handler_test.go
@@ -237,14 +237,10 @@ func createMockAgentWithInputRequired() server.OpenAICompatibleAgent {
 	streamChan := make(chan cloudevents.Event, 1)
 
 	inputMessage := &types.Message{
-		Kind:      "input_required",
 		MessageID: "stream-input-req-123",
 		Role:      "assistant",
 		Parts: []types.Part{
-			types.TextPart{
-				Kind: "text",
-				Text: "I need more information from you to continue.",
-			},
+			types.CreateTextPart("I need more information from you to continue."),
 		},
 	}
 

--- a/server/task_manager.go
+++ b/server/task_manager.go
@@ -153,8 +153,6 @@ func (tm *DefaultTaskManager) UnregisterTaskCancelFunc(taskID string) {
 
 // CreateTask creates a new task with message history managed within the task
 func (tm *DefaultTaskManager) CreateTask(contextID string, state types.TaskState, message *types.Message) *types.Task {
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-
 	var history []types.Message
 
 	if message != nil {
@@ -162,12 +160,11 @@ func (tm *DefaultTaskManager) CreateTask(contextID string, state types.TaskState
 	}
 
 	task := &types.Task{
-		ID:   uuid.New().String(),
-		Kind: "task",
+		ID: uuid.New().String(),
 		Status: types.TaskStatus{
-			State:     state,
+			State:     string(state),
 			Message:   message,
-			Timestamp: &timestamp,
+			Timestamp: &types.Timestamp{},
 		},
 		ContextID: contextID,
 		History:   history,
@@ -197,8 +194,6 @@ func (tm *DefaultTaskManager) CreateTask(contextID string, state types.TaskState
 
 // CreateTaskWithHistory creates a new task with existing conversation history
 func (tm *DefaultTaskManager) CreateTaskWithHistory(contextID string, state types.TaskState, message *types.Message, history []types.Message) *types.Task {
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-
 	taskHistory := make([]types.Message, len(history))
 	copy(taskHistory, history)
 
@@ -207,12 +202,11 @@ func (tm *DefaultTaskManager) CreateTaskWithHistory(contextID string, state type
 	}
 
 	task := &types.Task{
-		ID:   uuid.New().String(),
-		Kind: "task",
+		ID: uuid.New().String(),
 		Status: types.TaskStatus{
-			State:     state,
+			State:     string(state),
 			Message:   message,
-			Timestamp: &timestamp,
+			Timestamp: &types.Timestamp{},
 		},
 		ContextID: contextID,
 		History:   taskHistory,
@@ -267,9 +261,8 @@ func (tm *DefaultTaskManager) UpdateState(taskID string, state types.TaskState) 
 		}
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-	task.Status.State = state
-	task.Status.Timestamp = &timestamp
+	task.Status.State = string(state)
+	task.Status.Timestamp = &types.Timestamp{}
 
 	if tm.isTaskFinalState(state) {
 		tm.UnregisterTaskCancelFunc(taskID)
@@ -305,10 +298,9 @@ func (tm *DefaultTaskManager) UpdateTask(task *types.Task) error {
 		return fmt.Errorf("task cannot be nil")
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-	task.Status.Timestamp = &timestamp
+	task.Status.Timestamp = &types.Timestamp{}
 
-	if tm.isTaskFinalState(task.Status.State) {
+	if tm.isTaskFinalState(types.TaskState(task.Status.State)) {
 		tm.UnregisterTaskCancelFunc(task.ID)
 
 		err := tm.storage.StoreDeadLetterTask(task)
@@ -344,10 +336,9 @@ func (tm *DefaultTaskManager) UpdateError(taskID string, message *types.Message)
 		return NewTaskNotFoundError(taskID)
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-	task.Status.State = types.TaskStateFailed
+	task.Status.State = string(types.TaskStateFailed)
 	task.Status.Message = message
-	task.Status.Timestamp = &timestamp
+	task.Status.Timestamp = &types.Timestamp{}
 
 	tm.UnregisterTaskCancelFunc(taskID)
 
@@ -372,7 +363,7 @@ func (tm *DefaultTaskManager) UpdateError(taskID string, message *types.Message)
 // sendPushNotifications sends push notifications for a task update
 func (tm *DefaultTaskManager) sendPushNotifications(taskID string, task *types.Task) {
 	configs, err := tm.ListTaskPushNotificationConfigs(types.ListTaskPushNotificationConfigParams{
-		ID: taskID,
+		Parent: taskID,
 	})
 	if err != nil {
 		tm.logger.Error("failed to retrieve push notification configs",
@@ -454,10 +445,9 @@ func (tm *DefaultTaskManager) ListTasks(params types.TaskListParams) (*types.Tas
 	}
 
 	result := &types.TaskList{
-		Tasks:  resultTasks,
-		Total:  len(totalTasks),
-		Limit:  filter.Limit,
-		Offset: filter.Offset,
+		Tasks:     resultTasks,
+		TotalSize: len(totalTasks),
+		PageSize:  filter.Limit,
 	}
 
 	tm.logger.Debug("listed tasks",
@@ -477,7 +467,7 @@ func (tm *DefaultTaskManager) CancelTask(taskID string) error {
 	}
 
 	if !tm.isTaskCancelable(task.Status.State) {
-		return NewTaskNotCancelableError(taskID, task.Status.State)
+		return NewTaskNotCancelableError(taskID, types.TaskState(task.Status.State))
 	}
 
 	tm.runningTasksMu.RLock()
@@ -490,9 +480,8 @@ func (tm *DefaultTaskManager) CancelTask(taskID string) error {
 		tm.UnregisterTaskCancelFunc(taskID)
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-	task.Status.State = types.TaskStateCanceled
-	task.Status.Timestamp = &timestamp
+	task.Status.State = string(types.TaskStateCanceled)
+	task.Status.Timestamp = &types.Timestamp{}
 
 	err := tm.storage.StoreDeadLetterTask(task)
 	if err != nil {
@@ -510,8 +499,9 @@ func (tm *DefaultTaskManager) CancelTask(taskID string) error {
 }
 
 // isTaskCancelable determines if a task can be canceled based on its current state
-func (tm *DefaultTaskManager) isTaskCancelable(state types.TaskState) bool {
-	switch state {
+func (tm *DefaultTaskManager) isTaskCancelable(state string) bool {
+	taskState := types.TaskState(state)
+	switch taskState {
 	case types.TaskStateCompleted, types.TaskStateFailed, types.TaskStateCanceled, types.TaskStateRejected:
 		return false
 	case types.TaskStateSubmitted, types.TaskStateWorking, types.TaskStateInputRequired, types.TaskStateAuthRequired, types.TaskStateUnknown:
@@ -555,7 +545,8 @@ func (tm *DefaultTaskManager) PollTaskStatus(taskID string, interval time.Durati
 				return nil, NewTaskNotFoundError(taskID)
 			}
 
-			switch task.Status.State {
+			taskState := types.TaskState(task.Status.State)
+			switch taskState {
 			case types.TaskStateCompleted, types.TaskStateFailed, types.TaskStateCanceled, types.TaskStateRejected:
 				return task, nil
 			case types.TaskStateInputRequired:
@@ -607,18 +598,15 @@ func (tm *DefaultTaskManager) UpdateConversationHistory(contextID string, messag
 		zap.String("context_id", contextID),
 		zap.Int("message_count", len(messages)))
 
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-
 	historyCopy := make([]types.Message, len(messages))
 	copy(historyCopy, messages)
 
 	task := &types.Task{
-		ID:   uuid.New().String(),
-		Kind: "task",
+		ID: uuid.New().String(),
 		Status: types.TaskStatus{
-			State:     types.TaskStateCompleted,
+			State:     string(types.TaskStateCompleted),
 			Message:   nil,
-			Timestamp: &timestamp,
+			Timestamp: &types.Timestamp{},
 		},
 		ContextID: contextID,
 		History:   historyCopy,
@@ -635,8 +623,9 @@ func (tm *DefaultTaskManager) SetTaskPushNotificationConfig(config types.TaskPus
 	tm.pushNotificationConfigsMu.Lock()
 	defer tm.pushNotificationConfigsMu.Unlock()
 
-	if _, ok := tm.pushNotificationConfigs[config.TaskID]; !ok {
-		tm.pushNotificationConfigs[config.TaskID] = make(map[string]*types.TaskPushNotificationConfig)
+	taskID := config.Name
+	if _, ok := tm.pushNotificationConfigs[taskID]; !ok {
+		tm.pushNotificationConfigs[taskID] = make(map[string]*types.TaskPushNotificationConfig)
 	}
 
 	configID := config.PushNotificationConfig.ID
@@ -646,10 +635,10 @@ func (tm *DefaultTaskManager) SetTaskPushNotificationConfig(config types.TaskPus
 		configID = &id
 	}
 
-	tm.pushNotificationConfigs[config.TaskID][*configID] = &config
+	tm.pushNotificationConfigs[taskID][*configID] = &config
 
 	tm.logger.Debug("push notification config set",
-		zap.String("task_id", config.TaskID),
+		zap.String("task_id", taskID),
 		zap.String("config_id", *configID))
 
 	return &config, nil
@@ -660,20 +649,14 @@ func (tm *DefaultTaskManager) GetTaskPushNotificationConfig(params types.GetTask
 	tm.pushNotificationConfigsMu.RLock()
 	defer tm.pushNotificationConfigsMu.RUnlock()
 
-	if configs, ok := tm.pushNotificationConfigs[params.ID]; ok {
-		if params.PushNotificationConfigID != nil {
-			if config, ok := configs[*params.PushNotificationConfigID]; ok {
-				return config, nil
-			}
-			return nil, fmt.Errorf("push notification config not found for task %s, config %s", params.ID, *params.PushNotificationConfigID)
-		}
-
+	taskID := params.Name
+	if configs, ok := tm.pushNotificationConfigs[taskID]; ok {
 		for _, config := range configs {
 			return config, nil
 		}
 	}
 
-	return nil, fmt.Errorf("no push notification configs found for task %s", params.ID)
+	return nil, fmt.Errorf("no push notification configs found for task %s", taskID)
 }
 
 // ListTaskPushNotificationConfigs lists all push notification configurations for a task
@@ -681,7 +664,8 @@ func (tm *DefaultTaskManager) ListTaskPushNotificationConfigs(params types.ListT
 	tm.pushNotificationConfigsMu.RLock()
 	defer tm.pushNotificationConfigsMu.RUnlock()
 
-	if configs, ok := tm.pushNotificationConfigs[params.ID]; ok {
+	taskID := params.Parent
+	if configs, ok := tm.pushNotificationConfigs[taskID]; ok {
 		var result []types.TaskPushNotificationConfig
 		for _, config := range configs {
 			result = append(result, *config)
@@ -697,17 +681,18 @@ func (tm *DefaultTaskManager) DeleteTaskPushNotificationConfig(params types.Dele
 	tm.pushNotificationConfigsMu.Lock()
 	defer tm.pushNotificationConfigsMu.Unlock()
 
-	if configs, ok := tm.pushNotificationConfigs[params.ID]; ok {
-		if _, ok := configs[params.PushNotificationConfigID]; ok {
-			delete(configs, params.PushNotificationConfigID)
+	taskID := params.Name
+	if configs, ok := tm.pushNotificationConfigs[taskID]; ok {
+		for configID := range configs {
+			delete(configs, configID)
 			tm.logger.Info("push notification config deleted",
-				zap.String("task_id", params.ID),
-				zap.String("config_id", params.PushNotificationConfigID))
+				zap.String("task_id", taskID),
+				zap.String("config_id", configID))
 			return nil
 		}
 	}
 
-	return fmt.Errorf("push notification config not found for task %s, config %s", params.ID, params.PushNotificationConfigID)
+	return fmt.Errorf("push notification config not found for task %s", taskID)
 }
 
 // TaskNotFoundError represents an error when a task is not found
@@ -746,10 +731,9 @@ func (tm *DefaultTaskManager) PauseTaskForInput(taskID string, message *types.Me
 		return NewTaskNotFoundError(taskID)
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-	task.Status.State = types.TaskStateInputRequired
+	task.Status.State = string(types.TaskStateInputRequired)
 	task.Status.Message = message
-	task.Status.Timestamp = &timestamp
+	task.Status.Timestamp = &types.Timestamp{}
 
 	if message != nil {
 		task.History = append(task.History, *message)
@@ -780,14 +764,13 @@ func (tm *DefaultTaskManager) ResumeTaskWithInput(taskID string, message *types.
 		return NewTaskNotFoundError(taskID)
 	}
 
-	if task.Status.State == types.TaskStateCompleted {
+	if task.Status.State == string(types.TaskStateCompleted) {
 		return fmt.Errorf("task %s is already completed and cannot be resumed, current state: %s", taskID, task.Status.State)
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
-	task.Status.State = types.TaskStateWorking
+	task.Status.State = string(types.TaskStateWorking)
 	task.Status.Message = message
-	task.Status.Timestamp = &timestamp
+	task.Status.Timestamp = &types.Timestamp{}
 
 	if message != nil {
 		task.History = append(task.History, *message)
@@ -818,7 +801,7 @@ func (tm *DefaultTaskManager) IsTaskPaused(taskID string) (bool, error) {
 		return false, NewTaskNotFoundError(taskID)
 	}
 
-	return task.Status.State == types.TaskStateInputRequired, nil
+	return task.Status.State == string(types.TaskStateInputRequired), nil
 }
 
 // SetRetentionConfig sets the task retention configuration and starts automatic cleanup

--- a/server/task_manager_test.go
+++ b/server/task_manager_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	server "github.com/inference-gateway/adk/server"
-	"github.com/inference-gateway/adk/server/config"
+	config "github.com/inference-gateway/adk/server/config"
 	types "github.com/inference-gateway/adk/types"
 	assert "github.com/stretchr/testify/assert"
 	zap "go.uber.org/zap"
@@ -27,10 +27,7 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 				MessageID: "msg-1",
 				Role:      "user",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "Test message",
-					},
+					types.CreateTextPart("Test message"),
 				},
 			},
 		},
@@ -42,10 +39,7 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 				MessageID: "msg-2",
 				Role:      "assistant",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "Processing...",
-					},
+					types.CreateTextPart("Processing..."),
 				},
 			},
 		},
@@ -57,10 +51,7 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 				MessageID: "msg-3",
 				Role:      "assistant",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "Task completed",
-					},
+					types.CreateTextPart("Task completed"),
 				},
 			},
 		},
@@ -72,10 +63,7 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 				MessageID: "msg-4",
 				Role:      "assistant",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "Task failed",
-					},
+					types.CreateTextPart("Task failed"),
 				},
 			},
 		},
@@ -127,10 +115,7 @@ func TestDefaultTaskManager_GetTask(t *testing.T) {
 		MessageID: "test-msg",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Test message",
-			},
+			types.CreateTextPart("Test message"),
 		},
 	}
 
@@ -259,10 +244,7 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 		MessageID: "msg-1",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Hello, what's the weather like?",
-			},
+			types.CreateTextPart("Hello, what's the weather like?"),
 		},
 	}
 
@@ -276,16 +258,13 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 		MessageID: "msg-response-1",
 		Role:      "assistant",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "It's sunny today with a temperature of 72°F.",
-			},
+			types.CreateTextPart("It's sunny today with a temperature of 72°F."),
 		},
 	}
 
 	task1.History = append(task1.History, *assistantResponse1)
 
-	task1.Status.State = types.TaskStateCompleted
+	task1.Status.State = string(types.TaskStateCompleted)
 	err := taskManager.UpdateTask(task1)
 	assert.NoError(t, err)
 
@@ -298,10 +277,7 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 		MessageID: "msg-2",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "What about tomorrow?",
-			},
+			types.CreateTextPart("What about tomorrow?"),
 		},
 	}
 
@@ -319,16 +295,13 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 		MessageID: "msg-response-2",
 		Role:      "assistant",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Tomorrow will be partly cloudy with a high of 68°F.",
-			},
+			types.CreateTextPart("Tomorrow will be partly cloudy with a high of 68°F."),
 		},
 	}
 
 	task2.History = append(task2.History, *assistantResponse2)
 
-	task2.Status.State = types.TaskStateCompleted
+	task2.Status.State = string(types.TaskStateCompleted)
 	err = taskManager.UpdateTask(task2)
 	assert.NoError(t, err)
 
@@ -343,10 +316,7 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 		MessageID: "msg-3",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Should I bring an umbrella?",
-			},
+			types.CreateTextPart("Should I bring an umbrella?"),
 		},
 	}
 
@@ -369,10 +339,7 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 		MessageID: "msg-1",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Message for context 1",
-			},
+			types.CreateTextPart("Message for context 1"),
 		},
 	}
 
@@ -380,10 +347,7 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 		MessageID: "msg-2",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Message for context 2",
-			},
+			types.CreateTextPart("Message for context 2"),
 		},
 	}
 
@@ -400,21 +364,18 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 		MessageID: "response-1",
 		Role:      "assistant",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Response to context 1",
-			},
+			types.CreateTextPart("Response to context 1"),
 		},
 	}
 
 	task1.History = append(task1.History, *response1)
 
-	task1.Status.State = types.TaskStateCompleted
+	task1.Status.State = string(types.TaskStateCompleted)
 	var err error
 	err = taskManager.UpdateTask(task1)
 	assert.NoError(t, err)
 
-	task2.Status.State = types.TaskStateCompleted
+	task2.Status.State = string(types.TaskStateCompleted)
 	err = taskManager.UpdateTask(task2)
 	assert.NoError(t, err)
 
@@ -422,10 +383,7 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 		MessageID: "msg-3",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Follow-up for context 1",
-			},
+			types.CreateTextPart("Follow-up for context 1"),
 		},
 	}
 
@@ -438,10 +396,7 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 		MessageID: "msg-4",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Follow-up for context 2",
-			},
+			types.CreateTextPart("Follow-up for context 2"),
 		},
 	}
 
@@ -473,10 +428,7 @@ func TestDefaultTaskManager_GetConversationHistory(t *testing.T) {
 		MessageID: "msg-1",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Test message",
-			},
+			types.CreateTextPart("Test message"),
 		},
 	}
 
@@ -486,16 +438,13 @@ func TestDefaultTaskManager_GetConversationHistory(t *testing.T) {
 		MessageID: "response-1",
 		Role:      "assistant",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Test response",
-			},
+			types.CreateTextPart("Test response"),
 		},
 	}
 
 	task.History = append(task.History, *response)
 
-	task.Status.State = types.TaskStateCompleted
+	task.Status.State = string(types.TaskStateCompleted)
 	err := taskManager.UpdateTask(task)
 	assert.NoError(t, err)
 
@@ -505,10 +454,7 @@ func TestDefaultTaskManager_GetConversationHistory(t *testing.T) {
 	assert.Equal(t, *response, history[1])
 
 	history[0].Parts = []types.Part{
-		map[string]any{
-			"kind": "text",
-			"text": "Modified message",
-		},
+		types.CreateTextPart("Modified message"),
 	}
 
 	freshHistory := taskManager.GetConversationHistory(contextID)
@@ -527,20 +473,14 @@ func TestDefaultTaskManager_UpdateConversationHistory(t *testing.T) {
 			MessageID: "msg-1",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "First message",
-				},
+				types.CreateTextPart("First message"),
 			},
 		},
 		{
 			MessageID: "msg-2",
 			Role:      "assistant",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "First response",
-				},
+				types.CreateTextPart("First response"),
 			},
 		},
 	}
@@ -553,10 +493,7 @@ func TestDefaultTaskManager_UpdateConversationHistory(t *testing.T) {
 	assert.Equal(t, messages[1], history[1])
 
 	messages[0].Parts = []types.Part{
-		map[string]any{
-			"kind": "text",
-			"text": "Modified message",
-		},
+		types.CreateTextPart("Modified message"),
 	}
 
 	freshHistory := taskManager.GetConversationHistory(contextID)
@@ -573,7 +510,7 @@ func TestDefaultTaskManager_TaskRetention(t *testing.T) {
 		message := &types.Message{
 			MessageID: fmt.Sprintf("completed-msg-%d", i),
 			Role:      "user",
-			Parts:     []types.Part{map[string]any{"kind": "text", "text": fmt.Sprintf("Completed message %d", i)}},
+			Parts:     []types.Part{types.CreateTextPart(fmt.Sprintf("Completed message %d", i))},
 		}
 		task := taskManager.CreateTask(contextID, types.TaskStateCompleted, message)
 		assert.NotNil(t, task)
@@ -583,7 +520,7 @@ func TestDefaultTaskManager_TaskRetention(t *testing.T) {
 		message := &types.Message{
 			MessageID: fmt.Sprintf("failed-msg-%d", i),
 			Role:      "user",
-			Parts:     []types.Part{map[string]any{"kind": "text", "text": fmt.Sprintf("Failed message %d", i)}},
+			Parts:     []types.Part{types.CreateTextPart(fmt.Sprintf("Failed message %d", i))},
 		}
 		task := taskManager.CreateTask(contextID, types.TaskStateFailed, message)
 		assert.NotNil(t, task)
@@ -611,9 +548,9 @@ func TestDefaultTaskManager_TaskRetention(t *testing.T) {
 	failedCount := 0
 	for _, task := range allTasks.Tasks {
 		switch task.Status.State {
-		case types.TaskStateCompleted:
+		case string(types.TaskStateCompleted):
 			completedCount++
-		case types.TaskStateFailed:
+		case string(types.TaskStateFailed):
 			failedCount++
 		}
 	}
@@ -632,15 +569,12 @@ func TestDefaultTaskManager_ConversationHistoryLimitViaCreateTask(t *testing.T) 
 		MessageID: "msg-1",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "First message",
-			},
+			types.CreateTextPart("First message"),
 		},
 	}
 	task1 := taskManager.CreateTask(contextID, types.TaskStateSubmitted, message1)
 
-	task1.Status.State = types.TaskStateCompleted
+	task1.Status.State = string(types.TaskStateCompleted)
 	err := taskManager.UpdateTask(task1)
 	assert.NoError(t, err)
 
@@ -648,10 +582,7 @@ func TestDefaultTaskManager_ConversationHistoryLimitViaCreateTask(t *testing.T) 
 		MessageID: "msg-2",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Second message",
-			},
+			types.CreateTextPart("Second message"),
 		},
 	}
 	task2 := taskManager.CreateTask(contextID, types.TaskStateSubmitted, message2)
@@ -660,10 +591,7 @@ func TestDefaultTaskManager_ConversationHistoryLimitViaCreateTask(t *testing.T) 
 		MessageID: "msg-3",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Third message",
-			},
+			types.CreateTextPart("Third message"),
 		},
 	}
 	task3 := taskManager.CreateTask(contextID, types.TaskStateSubmitted, message3)
@@ -745,10 +673,7 @@ func TestDefaultTaskManager_CancelTask_StateValidation(t *testing.T) {
 				MessageID: "test-msg",
 				Role:      "user",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "Test message",
-					},
+					types.CreateTextPart("Test message"),
 				},
 			})
 
@@ -784,10 +709,7 @@ func TestDefaultTaskManager_PauseTaskForInput(t *testing.T) {
 			MessageID: "initial-msg",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Initial message",
-				},
+				types.CreateTextPart("Initial message"),
 			},
 		})
 
@@ -798,10 +720,7 @@ func TestDefaultTaskManager_PauseTaskForInput(t *testing.T) {
 			MessageID: "pause-msg",
 			Role:      "assistant",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Please provide more information",
-				},
+				types.CreateTextPart("Please provide more information"),
 			},
 		}
 
@@ -856,10 +775,7 @@ func TestDefaultTaskManager_ResumeTaskWithInput(t *testing.T) {
 			MessageID: "resume-msg",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Here is the additional information",
-				},
+				types.CreateTextPart("Here is the additional information"),
 			},
 		}
 
@@ -984,10 +900,7 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 		MessageID: "initial-msg",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Process this request",
-			},
+			types.CreateTextPart("Process this request"),
 		},
 	}
 	task := taskManager.CreateTask("test-context", types.TaskStateWorking, initialMessage)
@@ -999,10 +912,7 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 		MessageID: "pause-msg",
 		Role:      "assistant",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "I need more information. What is your preference?",
-			},
+			types.CreateTextPart("I need more information. What is your preference?"),
 		},
 	}
 	err = taskManager.PauseTaskForInput(task.ID, pauseMessage)
@@ -1027,10 +937,7 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 		MessageID: "resume-msg",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "I prefer option A",
-			},
+			types.CreateTextPart("I prefer option A"),
 		},
 	}
 	err = taskManager.ResumeTaskWithInput(task2.ID, resumeMessage)

--- a/server/task_manager_test.go
+++ b/server/task_manager_test.go
@@ -25,7 +25,7 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			state:     types.TaskStateSubmitted,
 			message: &types.Message{
 				MessageID: "msg-1",
-				Role:      "user",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Test message"),
 				},
@@ -37,7 +37,7 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			state:     types.TaskStateWorking,
 			message: &types.Message{
 				MessageID: "msg-2",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Processing..."),
 				},
@@ -49,7 +49,7 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			state:     types.TaskStateCompleted,
 			message: &types.Message{
 				MessageID: "msg-3",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Task completed"),
 				},
@@ -61,7 +61,7 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			state:     types.TaskStateFailed,
 			message: &types.Message{
 				MessageID: "msg-4",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Task failed"),
 				},
@@ -250,7 +250,7 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 
 	assistantResponse1 := &types.Message{
 		MessageID: "msg-response-1",
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
 			types.CreateTextPart("It's sunny today with a temperature of 72°F."),
 		},
@@ -287,7 +287,7 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 
 	assistantResponse2 := &types.Message{
 		MessageID: "msg-response-2",
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
 			types.CreateTextPart("Tomorrow will be partly cloudy with a high of 68°F."),
 		},
@@ -356,7 +356,7 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 
 	response1 := &types.Message{
 		MessageID: "response-1",
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
 			types.CreateTextPart("Response to context 1"),
 		},
@@ -430,7 +430,7 @@ func TestDefaultTaskManager_GetConversationHistory(t *testing.T) {
 
 	response := &types.Message{
 		MessageID: "response-1",
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
 			types.CreateTextPart("Test response"),
 		},
@@ -466,14 +466,14 @@ func TestDefaultTaskManager_UpdateConversationHistory(t *testing.T) {
 	messages := []types.Message{
 		{
 			MessageID: "msg-1",
-			Role:      "user",
+			Role:      types.RoleUser,
 			Parts: []types.Part{
 				types.CreateTextPart("First message"),
 			},
 		},
 		{
 			MessageID: "msg-2",
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateTextPart("First response"),
 			},
@@ -703,7 +703,7 @@ func TestDefaultTaskManager_PauseTaskForInput(t *testing.T) {
 	t.Run("pause existing task successfully", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateWorking, &types.Message{
 			MessageID: "initial-msg",
-			Role:      "user",
+			Role:      types.RoleUser,
 			Parts: []types.Part{
 				types.CreateTextPart("Initial message"),
 			},
@@ -714,7 +714,7 @@ func TestDefaultTaskManager_PauseTaskForInput(t *testing.T) {
 
 		pauseMessage := &types.Message{
 			MessageID: "pause-msg",
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateTextPart("Please provide more information"),
 			},
@@ -894,7 +894,7 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 
 	initialMessage := &types.Message{
 		MessageID: "initial-msg",
-		Role:      "user",
+		Role:      types.RoleUser,
 		Parts: []types.Part{
 			types.CreateTextPart("Process this request"),
 		},
@@ -906,7 +906,7 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 
 	pauseMessage := &types.Message{
 		MessageID: "pause-msg",
-		Role:      "assistant",
+		Role:      types.RoleAgent,
 		Parts: []types.Part{
 			types.CreateTextPart("I need more information. What is your preference?"),
 		},

--- a/server/task_manager_test.go
+++ b/server/task_manager_test.go
@@ -24,7 +24,6 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			contextID: "context-1",
 			state:     types.TaskStateSubmitted,
 			message: &types.Message{
-				Kind:      "message",
 				MessageID: "msg-1",
 				Role:      "user",
 				Parts: []types.Part{
@@ -40,7 +39,6 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			contextID: "context-2",
 			state:     types.TaskStateWorking,
 			message: &types.Message{
-				Kind:      "message",
 				MessageID: "msg-2",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -56,7 +54,6 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			contextID: "context-3",
 			state:     types.TaskStateCompleted,
 			message: &types.Message{
-				Kind:      "message",
 				MessageID: "msg-3",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -72,7 +69,6 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			contextID: "context-4",
 			state:     types.TaskStateFailed,
 			message: &types.Message{
-				Kind:      "message",
 				MessageID: "msg-4",
 				Role:      "assistant",
 				Parts: []types.Part{
@@ -94,7 +90,6 @@ func TestDefaultTaskManager_CreateTask(t *testing.T) {
 			contextID: "",
 			state:     types.TaskStateSubmitted,
 			message: &types.Message{
-				Kind:      "message",
 				MessageID: "msg-6",
 				Role:      "user",
 			},
@@ -129,7 +124,6 @@ func TestDefaultTaskManager_GetTask(t *testing.T) {
 	taskManager := server.NewDefaultTaskManager(logger)
 
 	message := &types.Message{
-		Kind:      "message",
 		MessageID: "test-msg",
 		Role:      "user",
 		Parts: []types.Part{
@@ -217,7 +211,6 @@ func TestDefaultTaskManager_ConcurrentAccess(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func(index int) {
 			message := &types.Message{
-				Kind:      "message",
 				MessageID: "concurrent-msg",
 				Role:      "user",
 			}
@@ -263,7 +256,6 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 	contextID := "test-conversation-context"
 
 	firstMessage := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-1",
 		Role:      "user",
 		Parts: []types.Part{
@@ -281,7 +273,6 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 	assert.Equal(t, *firstMessage, task1.History[0])
 
 	assistantResponse1 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-response-1",
 		Role:      "assistant",
 		Parts: []types.Part{
@@ -304,7 +295,6 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 	assert.Equal(t, *assistantResponse1, completedHistory[1])
 
 	secondMessage := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-2",
 		Role:      "user",
 		Parts: []types.Part{
@@ -326,7 +316,6 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 	assert.Equal(t, *secondMessage, task2.History[2])
 
 	assistantResponse2 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-response-2",
 		Role:      "assistant",
 		Parts: []types.Part{
@@ -351,7 +340,6 @@ func TestDefaultTaskManager_ConversationContextPreservation(t *testing.T) {
 	assert.Equal(t, *assistantResponse2, finalHistory[3])
 
 	thirdMessage := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-3",
 		Role:      "user",
 		Parts: []types.Part{
@@ -378,7 +366,6 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 	contextID2 := "context-2"
 
 	message1 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-1",
 		Role:      "user",
 		Parts: []types.Part{
@@ -390,7 +377,6 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 	}
 
 	message2 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-2",
 		Role:      "user",
 		Parts: []types.Part{
@@ -411,7 +397,6 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 	assert.Equal(t, *message2, task2.History[0])
 
 	response1 := &types.Message{
-		Kind:      "message",
 		MessageID: "response-1",
 		Role:      "assistant",
 		Parts: []types.Part{
@@ -434,7 +419,6 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 	assert.NoError(t, err)
 
 	message3 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-3",
 		Role:      "user",
 		Parts: []types.Part{
@@ -451,7 +435,6 @@ func TestDefaultTaskManager_ConversationHistoryIsolation(t *testing.T) {
 	assert.Equal(t, *message3, task3.History[0])
 
 	message4 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-4",
 		Role:      "user",
 		Parts: []types.Part{
@@ -487,7 +470,6 @@ func TestDefaultTaskManager_GetConversationHistory(t *testing.T) {
 	assert.Empty(t, history)
 
 	message := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-1",
 		Role:      "user",
 		Parts: []types.Part{
@@ -501,7 +483,6 @@ func TestDefaultTaskManager_GetConversationHistory(t *testing.T) {
 	task := taskManager.CreateTask(contextID, types.TaskStateSubmitted, message)
 
 	response := &types.Message{
-		Kind:      "message",
 		MessageID: "response-1",
 		Role:      "assistant",
 		Parts: []types.Part{
@@ -543,7 +524,6 @@ func TestDefaultTaskManager_UpdateConversationHistory(t *testing.T) {
 
 	messages := []types.Message{
 		{
-			Kind:      "message",
 			MessageID: "msg-1",
 			Role:      "user",
 			Parts: []types.Part{
@@ -554,7 +534,6 @@ func TestDefaultTaskManager_UpdateConversationHistory(t *testing.T) {
 			},
 		},
 		{
-			Kind:      "message",
 			MessageID: "msg-2",
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -592,7 +571,6 @@ func TestDefaultTaskManager_TaskRetention(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		message := &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("completed-msg-%d", i),
 			Role:      "user",
 			Parts:     []types.Part{map[string]any{"kind": "text", "text": fmt.Sprintf("Completed message %d", i)}},
@@ -603,7 +581,6 @@ func TestDefaultTaskManager_TaskRetention(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		message := &types.Message{
-			Kind:      "message",
 			MessageID: fmt.Sprintf("failed-msg-%d", i),
 			Role:      "user",
 			Parts:     []types.Part{map[string]any{"kind": "text", "text": fmt.Sprintf("Failed message %d", i)}},
@@ -652,7 +629,6 @@ func TestDefaultTaskManager_ConversationHistoryLimitViaCreateTask(t *testing.T) 
 	contextID := "test-context"
 
 	message1 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-1",
 		Role:      "user",
 		Parts: []types.Part{
@@ -669,7 +645,6 @@ func TestDefaultTaskManager_ConversationHistoryLimitViaCreateTask(t *testing.T) 
 	assert.NoError(t, err)
 
 	message2 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-2",
 		Role:      "user",
 		Parts: []types.Part{
@@ -682,7 +657,6 @@ func TestDefaultTaskManager_ConversationHistoryLimitViaCreateTask(t *testing.T) 
 	task2 := taskManager.CreateTask(contextID, types.TaskStateSubmitted, message2)
 
 	message3 := &types.Message{
-		Kind:      "message",
 		MessageID: "msg-3",
 		Role:      "user",
 		Parts: []types.Part{
@@ -768,7 +742,6 @@ func TestDefaultTaskManager_CancelTask_StateValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			task := taskManager.CreateTask("test-context", tt.initialState, &types.Message{
-				Kind:      "message",
 				MessageID: "test-msg",
 				Role:      "user",
 				Parts: []types.Part{
@@ -808,7 +781,6 @@ func TestDefaultTaskManager_PauseTaskForInput(t *testing.T) {
 
 	t.Run("pause existing task successfully", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateWorking, &types.Message{
-			Kind:      "message",
 			MessageID: "initial-msg",
 			Role:      "user",
 			Parts: []types.Part{
@@ -823,7 +795,6 @@ func TestDefaultTaskManager_PauseTaskForInput(t *testing.T) {
 		assert.NoError(t, err)
 
 		pauseMessage := &types.Message{
-			Kind:      "message",
 			MessageID: "pause-msg",
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -882,7 +853,6 @@ func TestDefaultTaskManager_ResumeTaskWithInput(t *testing.T) {
 		assert.NoError(t, err)
 
 		resumeMessage := &types.Message{
-			Kind:      "message",
 			MessageID: "resume-msg",
 			Role:      "user",
 			Parts: []types.Part{
@@ -1011,7 +981,6 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 	taskManager := server.NewDefaultTaskManager(logger)
 
 	initialMessage := &types.Message{
-		Kind:      "message",
 		MessageID: "initial-msg",
 		Role:      "user",
 		Parts: []types.Part{
@@ -1027,7 +996,6 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 	assert.NoError(t, err)
 
 	pauseMessage := &types.Message{
-		Kind:      "message",
 		MessageID: "pause-msg",
 		Role:      "assistant",
 		Parts: []types.Part{
@@ -1056,7 +1024,6 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 	assert.NoError(t, err)
 
 	resumeMessage := &types.Message{
-		Kind:      "message",
 		MessageID: "resume-msg",
 		Role:      "user",
 		Parts: []types.Part{

--- a/server/test_helpers.go
+++ b/server/test_helpers.go
@@ -1,0 +1,3 @@
+package server
+
+// This file has been moved to test_helpers_test.go

--- a/server/test_helpers_test.go
+++ b/server/test_helpers_test.go
@@ -1,0 +1,11 @@
+package server_test
+
+// boolPtr returns a pointer to a boolean value
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// stringPtr returns a pointer to a string value
+func stringPtr(s string) *string {
+	return &s
+}

--- a/server/utils/message_converter.go
+++ b/server/utils/message_converter.go
@@ -320,7 +320,6 @@ func (c *messageConverter) ConvertFromSDK(response sdk.Message) (*types.Message,
 	messageID := fmt.Sprintf("%s-%d", role, time.Now().UnixNano())
 
 	message := &types.Message{
-		Kind:      "message",
 		MessageID: messageID,
 		Role:      role,
 		Parts:     []types.Part{},

--- a/server/utils/message_converter.go
+++ b/server/utils/message_converter.go
@@ -68,7 +68,7 @@ func (c *messageConverter) convertSingleMessage(msg types.Message) (sdk.Message,
 		if part.Text != nil {
 			content += *part.Text
 		} else if part.Data != nil {
-			if err := c.processDataPart(part.Data.Data, role, &content, &toolCallId, &toolCalls); err != nil {
+			if err := c.processDataPart(part.Data.Data, string(role), &content, &toolCallId, &toolCalls); err != nil {
 				c.logger.Warn("failed to process DataPart",
 					zap.String("message_id", msg.MessageID),
 					zap.Error(err))
@@ -277,7 +277,7 @@ func (c *messageConverter) ConvertFromSDK(response sdk.Message) (*types.Message,
 
 	message := &types.Message{
 		MessageID: messageID,
-		Role:      role,
+		Role:      types.Role(role),
 		Parts:     []types.Part{},
 	}
 

--- a/server/utils/message_converter_bench_test.go
+++ b/server/utils/message_converter_bench_test.go
@@ -17,30 +17,21 @@ func BenchmarkMessageConverter_ConvertToSDK(b *testing.B) {
 			MessageID: "bench-msg-1",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "This is a benchmark test message with some content to convert.",
-				},
+				types.CreateTextPart("This is a benchmark test message with some content to convert."),
 			},
 		},
 		{
 			MessageID: "bench-msg-2",
 			Role:      "assistant",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "This is a response message from the assistant.",
-				},
+				types.CreateTextPart("This is a response message from the assistant."),
 			},
 		},
 		{
 			MessageID: "bench-msg-3",
 			Role:      "system",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "System message with instructions for the assistant.",
-				},
+				types.CreateTextPart("System message with instructions for the assistant."),
 			},
 		},
 	}
@@ -81,20 +72,14 @@ func BenchmarkMessageConverter_ConvertToSDK_StronglyTyped(b *testing.B) {
 			MessageID: "bench-typed-msg-1",
 			Role:      "user",
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: "This is a strongly-typed benchmark test message.",
-				},
+				types.CreateTextPart("This is a strongly-typed benchmark test message."),
 			},
 		},
 		{
 			MessageID: "bench-typed-msg-2",
 			Role:      "assistant",
 			Parts: []types.Part{
-				types.TextPart{
-					Kind: "text",
-					Text: "This is a strongly-typed response message.",
-				},
+				types.CreateTextPart("This is a strongly-typed response message."),
 			},
 		},
 	}
@@ -122,10 +107,7 @@ func BenchmarkMessageConverter_ConvertToSDK_LargeMessages(b *testing.B) {
 			MessageID: "bench-large-msg",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": largeContent,
-				},
+				types.CreateTextPart(largeContent),
 			},
 		},
 	}
@@ -149,10 +131,7 @@ func BenchmarkMessageConverter_ConvertToSDK_ManyMessages(b *testing.B) {
 			MessageID: "bench-many-msg-" + string(rune(i)),
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Message number " + string(rune(i)),
-				},
+				types.CreateTextPart("Message number " + string(rune(i))),
 			},
 		}
 	}
@@ -170,10 +149,7 @@ func BenchmarkMessageConverter_ValidateMessagePart(b *testing.B) {
 	logger := zap.NewNop()
 	converter := NewMessageConverter(logger)
 
-	part := map[string]any{
-		"kind": "text",
-		"text": "This is a test message part for validation benchmarking.",
-	}
+	part := types.CreateTextPart("This is a test message part for validation benchmarking.")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -188,10 +164,7 @@ func BenchmarkMessageConverter_ValidateMessagePart_StronglyTyped(b *testing.B) {
 	logger := zap.NewNop()
 	converter := NewMessageConverter(logger)
 
-	part := types.TextPart{
-		Kind: "text",
-		Text: "This is a strongly-typed test message part for validation benchmarking.",
-	}
+	part := types.CreateTextPart("This is a strongly-typed test message part for validation benchmarking.")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/server/utils/message_converter_bench_test.go
+++ b/server/utils/message_converter_bench_test.go
@@ -14,7 +14,6 @@ func BenchmarkMessageConverter_ConvertToSDK(b *testing.B) {
 
 	messages := []types.Message{
 		{
-			Kind:      "message",
 			MessageID: "bench-msg-1",
 			Role:      "user",
 			Parts: []types.Part{
@@ -25,7 +24,6 @@ func BenchmarkMessageConverter_ConvertToSDK(b *testing.B) {
 			},
 		},
 		{
-			Kind:      "message",
 			MessageID: "bench-msg-2",
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -36,7 +34,6 @@ func BenchmarkMessageConverter_ConvertToSDK(b *testing.B) {
 			},
 		},
 		{
-			Kind:      "message",
 			MessageID: "bench-msg-3",
 			Role:      "system",
 			Parts: []types.Part{
@@ -81,7 +78,6 @@ func BenchmarkMessageConverter_ConvertToSDK_StronglyTyped(b *testing.B) {
 
 	messages := []types.Message{
 		{
-			Kind:      "message",
 			MessageID: "bench-typed-msg-1",
 			Role:      "user",
 			Parts: []types.Part{
@@ -92,7 +88,6 @@ func BenchmarkMessageConverter_ConvertToSDK_StronglyTyped(b *testing.B) {
 			},
 		},
 		{
-			Kind:      "message",
 			MessageID: "bench-typed-msg-2",
 			Role:      "assistant",
 			Parts: []types.Part{
@@ -124,7 +119,6 @@ func BenchmarkMessageConverter_ConvertToSDK_LargeMessages(b *testing.B) {
 
 	messages := []types.Message{
 		{
-			Kind:      "message",
 			MessageID: "bench-large-msg",
 			Role:      "user",
 			Parts: []types.Part{
@@ -152,7 +146,6 @@ func BenchmarkMessageConverter_ConvertToSDK_ManyMessages(b *testing.B) {
 	messages := make([]types.Message, 100)
 	for i := 0; i < 100; i++ {
 		messages[i] = types.Message{
-			Kind:      "message",
 			MessageID: "bench-many-msg-" + string(rune(i)),
 			Role:      "user",
 			Parts: []types.Part{

--- a/server/utils/message_converter_bench_test.go
+++ b/server/utils/message_converter_bench_test.go
@@ -15,14 +15,14 @@ func BenchmarkMessageConverter_ConvertToSDK(b *testing.B) {
 	messages := []types.Message{
 		{
 			MessageID: "bench-msg-1",
-			Role:      "user",
+			Role:      types.RoleUser,
 			Parts: []types.Part{
 				types.CreateTextPart("This is a benchmark test message with some content to convert."),
 			},
 		},
 		{
 			MessageID: "bench-msg-2",
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateTextPart("This is a response message from the assistant."),
 			},
@@ -70,14 +70,14 @@ func BenchmarkMessageConverter_ConvertToSDK_StronglyTyped(b *testing.B) {
 	messages := []types.Message{
 		{
 			MessageID: "bench-typed-msg-1",
-			Role:      "user",
+			Role:      types.RoleUser,
 			Parts: []types.Part{
 				types.CreateTextPart("This is a strongly-typed benchmark test message."),
 			},
 		},
 		{
 			MessageID: "bench-typed-msg-2",
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateTextPart("This is a strongly-typed response message."),
 			},

--- a/server/utils/message_converter_test.go
+++ b/server/utils/message_converter_test.go
@@ -27,10 +27,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-1",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Hello, world!",
-						},
+						types.CreateTextPart("Hello, world!"),
 					},
 				},
 			},
@@ -49,10 +46,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-2",
 					Role:      "assistant",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Hi there!",
-						},
+						types.CreateTextPart("Hi there!"),
 					},
 				},
 			},
@@ -71,10 +65,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-3",
 					Role:      "system",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "You are a helpful assistant.",
-						},
+						types.CreateTextPart("You are a helpful assistant."),
 					},
 				},
 			},
@@ -93,10 +84,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-4",
 					Role:      "",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Default role test",
-						},
+						types.CreateTextPart("Default role test"),
 					},
 				},
 			},
@@ -115,14 +103,8 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-5",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Part 1. ",
-						},
-						map[string]any{
-							"kind": "text",
-							"text": "Part 2.",
-						},
+						types.CreateTextPart("Part 1. "),
+						types.CreateTextPart("Part 2."),
 					},
 				},
 			},
@@ -141,14 +123,11 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-6",
 					Role:      "tool",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "data",
-							"data": map[string]any{
-								"tool_call_id": "call_test_function",
-								"tool_name":    "test_function",
-								"result":       "Tool execution result",
-							},
-						},
+						types.CreateDataPart(map[string]any{
+							"tool_call_id": "call_test_function",
+							"tool_name":    "test_function",
+							"result":       "Tool execution result",
+						}),
 					},
 				},
 			},
@@ -171,10 +150,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-7",
 					Role:      "user",
 					Parts: []types.Part{
-						types.TextPart{
-							Kind: "text",
-							Text: "Strongly typed message",
-						},
+						types.CreateTextPart("Strongly typed message"),
 					},
 				},
 			},
@@ -193,18 +169,8 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-8",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Please analyze this file: ",
-						},
-						types.FilePart{
-							Kind: "file",
-							File: map[string]any{
-								"name":     "test.txt",
-								"mimeType": "text/plain",
-								"bytes":    "base64encodedcontent",
-							},
-						},
+						types.CreateTextPart("Please analyze this file: "),
+						types.CreateFilePart("test.txt", "text/plain", stringPtr("base64encodedcontent"), nil),
 					},
 				},
 			},
@@ -223,20 +189,14 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					MessageID: "test-msg-9",
 					Role:      "user",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "First message",
-						},
+						types.CreateTextPart("First message"),
 					},
 				},
 				{
 					MessageID: "test-msg-10",
 					Role:      "assistant",
 					Parts: []types.Part{
-						map[string]any{
-							"kind": "text",
-							"text": "Second message",
-						},
+						types.CreateTextPart("Second message"),
 					},
 				},
 			},
@@ -293,10 +253,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			expectedOutput: &types.Message{
 				Role: "user",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Hello from SDK",
-					},
+					types.CreateTextPart("Hello from SDK"),
 				},
 			},
 			expectError: false,
@@ -310,10 +267,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			expectedOutput: &types.Message{
 				Role: "assistant",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "Response from assistant",
-					},
+					types.CreateTextPart("Response from assistant"),
 				},
 			},
 			expectError: false,
@@ -327,10 +281,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			expectedOutput: &types.Message{
 				Role: "system",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "System instructions",
-					},
+					types.CreateTextPart("System instructions"),
 				},
 			},
 			expectError: false,
@@ -348,14 +299,11 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			expectedOutput: &types.Message{
 				Role: "tool",
 				Parts: []types.Part{
-					types.DataPart{
-						Kind: "data",
-						Data: map[string]any{
-							"tool_call_id": "call_123",
-							"tool_name":    "",
-							"result":       "Tool response",
-						},
-					},
+					types.CreateDataPart(map[string]any{
+						"tool_call_id": "call_123",
+						"tool_name":    "",
+						"result":       "Tool response",
+					}),
 				},
 			},
 			expectError: false,
@@ -382,25 +330,19 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			expectedOutput: &types.Message{
 				Role: "assistant",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "I'll help you with that",
-					},
-					types.DataPart{
-						Kind: "data",
-						Data: map[string]any{
-							"tool_calls": []sdk.ChatCompletionMessageToolCall{
-								{
-									Id:   "call_123",
-									Type: "function",
-									Function: sdk.ChatCompletionMessageToolCallFunction{
-										Name:      "get_weather",
-										Arguments: `{"location": "New York"}`,
-									},
+					types.CreateTextPart("I'll help you with that"),
+					types.CreateDataPart(map[string]any{
+						"tool_calls": []sdk.ChatCompletionMessageToolCall{
+							{
+								Id:   "call_123",
+								Type: "function",
+								Function: sdk.ChatCompletionMessageToolCallFunction{
+									Name:      "get_weather",
+									Arguments: `{"location": "New York"}`,
 								},
 							},
 						},
-					},
+					}),
 				},
 			},
 			expectError: false,
@@ -414,10 +356,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			expectedOutput: &types.Message{
 				Role: "assistant",
 				Parts: []types.Part{
-					types.TextPart{
-						Kind: "text",
-						Text: "",
-					},
+					types.CreateTextPart(""),
 				},
 			},
 			expectError: false,
@@ -434,45 +373,30 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedOutput.Kind, result.Kind)
 			assert.Equal(t, tt.expectedOutput.Role, result.Role)
 			assert.Equal(t, len(tt.expectedOutput.Parts), len(result.Parts))
 
 			for i, expectedPart := range tt.expectedOutput.Parts {
-				switch expectedPart := expectedPart.(type) {
-				case types.TextPart:
-					resultPart, ok := result.Parts[i].(types.TextPart)
-					require.True(t, ok, "Expected result part to be TextPart")
-					assert.Equal(t, expectedPart.Kind, resultPart.Kind)
-					assert.Equal(t, expectedPart.Text, resultPart.Text)
-					assert.Equal(t, expectedPart.Metadata, resultPart.Metadata)
-				case types.DataPart:
-					resultPart, ok := result.Parts[i].(types.DataPart)
-					require.True(t, ok, "Expected result part to be DataPart")
-					assert.Equal(t, expectedPart.Kind, resultPart.Kind)
-					assert.Equal(t, expectedPart.Data, resultPart.Data)
-					assert.Equal(t, expectedPart.Metadata, resultPart.Metadata)
-				case types.FilePart:
-					resultPart, ok := result.Parts[i].(types.FilePart)
-					require.True(t, ok, "Expected result part to be FilePart")
-					assert.Equal(t, expectedPart.Kind, resultPart.Kind)
-					assert.Equal(t, expectedPart.File, resultPart.File)
-					assert.Equal(t, expectedPart.Metadata, resultPart.Metadata)
-				case map[string]any:
-					resultPartMap, ok := result.Parts[i].(map[string]any)
-					require.True(t, ok, "Expected result part to be map[string]any")
-					assert.Equal(t, expectedPart["kind"], resultPartMap["kind"])
+				resultPart := result.Parts[i]
 
-					switch expectedPart["kind"] {
-					case "text":
-						assert.Equal(t, expectedPart["text"], resultPartMap["text"])
-					case "data":
-						expectedData := expectedPart["data"].(map[string]any)
-						resultData := resultPartMap["data"].(map[string]any)
-						assert.Equal(t, expectedData, resultData)
-					}
-				default:
-					t.Errorf("Unexpected part type: %T", expectedPart)
+				if expectedPart.Text != nil {
+					require.NotNil(t, resultPart.Text, "Expected result part to have Text")
+					assert.Equal(t, *expectedPart.Text, *resultPart.Text)
+				}
+
+				if expectedPart.Data != nil {
+					require.NotNil(t, resultPart.Data, "Expected result part to have Data")
+					assert.Equal(t, expectedPart.Data.Data, resultPart.Data.Data)
+				}
+
+				if expectedPart.File != nil {
+					require.NotNil(t, resultPart.File, "Expected result part to have File")
+					assert.Equal(t, expectedPart.File.Name, resultPart.File.Name)
+					assert.Equal(t, expectedPart.File.MediaType, resultPart.File.MediaType)
+				}
+
+				if expectedPart.Metadata != nil {
+					assert.Equal(t, expectedPart.Metadata, resultPart.Metadata)
 				}
 			}
 		})
@@ -490,121 +414,58 @@ func TestMessageConverter_ValidateMessagePart(t *testing.T) {
 		errorMsg    string
 	}{
 		{
-			name: "valid strongly-typed text part",
-			input: types.TextPart{
-				Kind: "text",
-				Text: "Valid text",
-			},
+			name:        "valid text part",
+			input:       types.CreateTextPart("Valid text"),
 			expectError: false,
 		},
 		{
-			name: "valid strongly-typed file part",
-			input: types.FilePart{
-				Kind: "file",
-				File: map[string]any{
-					"name":     "test.txt",
-					"mimeType": "text/plain",
+			name:        "valid file part",
+			input:       types.CreateFilePart("test.txt", "text/plain", nil, nil),
+			expectError: false,
+		},
+		{
+			name: "valid data part",
+			input: types.CreateDataPart(map[string]any{
+				"key": "value",
+			}),
+			expectError: false,
+		},
+		{
+			name:        "invalid text part (empty text)",
+			input:       types.CreateTextPart(""),
+			expectError: true,
+			errorMsg:    "text part has empty text field",
+		},
+		{
+			name: "invalid file part (missing name)",
+			input: types.Part{
+				File: &types.FilePart{
+					Name:      "",
+					MediaType: "text/plain",
 				},
 			},
-			expectError: false,
+			expectError: true,
+			errorMsg:    "file part missing name",
 		},
 		{
-			name: "valid strongly-typed data part",
-			input: types.DataPart{
-				Kind: "data",
-				Data: map[string]any{
-					"key": "value",
+			name: "invalid data part (nil data)",
+			input: types.Part{
+				Data: &types.DataPart{
+					Data: nil,
 				},
-			},
-			expectError: false,
-		},
-		{
-			name: "invalid strongly-typed text part (missing text)",
-			input: types.TextPart{
-				Kind: "text",
-				Text: "",
-			},
-			expectError: true,
-			errorMsg:    "text part missing text field",
-		},
-		{
-			name: "invalid strongly-typed file part (missing file)",
-			input: types.FilePart{
-				Kind: "file",
-				File: nil,
-			},
-			expectError: true,
-			errorMsg:    "file part missing file field",
-		},
-		{
-			name: "invalid strongly-typed data part (missing data)",
-			input: types.DataPart{
-				Kind: "data",
-				Data: nil,
 			},
 			expectError: true,
 			errorMsg:    "data part missing data field",
 		},
 		{
-			name: "valid map-based text part",
-			input: map[string]any{
-				"kind": "text",
-				"text": "Valid text content",
-			},
-			expectError: false,
-		},
-		{
-			name: "valid map-based data part",
-			input: map[string]any{
-				"kind": "data",
-				"data": map[string]any{
-					"result": "some result",
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "valid map-based file part",
-			input: map[string]any{
-				"kind": "file",
-				"file": map[string]any{
-					"name":     "test.txt",
-					"mimeType": "text/plain",
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "invalid map-based part (missing kind)",
-			input: map[string]any{
-				"text": "Missing kind field",
+			name: "invalid part with no fields set",
+			input: types.Part{
+				Text: nil,
+				Data: nil,
+				File: nil,
 			},
 			expectError: true,
-			errorMsg:    "message part missing kind field",
-		},
-		{
-			name: "invalid map-based part (non-string kind)",
-			input: map[string]any{
-				"kind": 123,
-				"text": "Invalid kind type",
-			},
-			expectError: true,
-			errorMsg:    "message part kind must be string",
-		},
-		{
-			name: "invalid map-based part (invalid kind value)",
-			input: map[string]any{
-				"kind": "invalid_kind",
-				"text": "Invalid kind value",
-			},
-			expectError: true,
-			errorMsg:    "invalid message part kind: invalid_kind",
-		},
-		{
-			name:        "unsupported part type",
-			input:       "unsupported string part",
-			expectError: true,
-			errorMsg:    "unsupported message part type",
+			errorMsg:    "part must have at least one field set",
 		},
 	}
 
@@ -632,10 +493,7 @@ func TestMessageConverter_RoundTrip(t *testing.T) {
 		MessageID: "round-trip-test",
 		Role:      "user",
 		Parts: []types.Part{
-			map[string]any{
-				"kind": "text",
-				"text": "Round trip test message",
-			},
+			types.CreateTextPart("Round trip test message"),
 		},
 	}
 
@@ -646,14 +504,12 @@ func TestMessageConverter_RoundTrip(t *testing.T) {
 	convertedMessage, err := converter.ConvertFromSDK(sdkMessages[0])
 	require.NoError(t, err)
 
-	assert.Equal(t, originalMessage.Kind, convertedMessage.Kind)
 	assert.Equal(t, originalMessage.Role, convertedMessage.Role)
 	assert.Len(t, convertedMessage.Parts, 1)
 
-	convertedPart, ok := convertedMessage.Parts[0].(types.TextPart)
-	require.True(t, ok, "Expected converted part to be TextPart")
-	assert.Equal(t, "text", convertedPart.Kind)
-	assert.Equal(t, "Round trip test message", convertedPart.Text)
+	convertedPart := convertedMessage.Parts[0]
+	require.NotNil(t, convertedPart.Text, "Expected converted part to have Text")
+	assert.Equal(t, "Round trip test message", *convertedPart.Text)
 }
 
 func TestMessageConverter_PerformanceWithManyMessages(t *testing.T) {
@@ -666,10 +522,7 @@ func TestMessageConverter_PerformanceWithManyMessages(t *testing.T) {
 			MessageID: "perf-test-" + string(rune(i)),
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "Performance test message number " + string(rune(i)),
-				},
+				types.CreateTextPart("Performance test message number " + string(rune(i))),
 			},
 		}
 	}
@@ -701,22 +554,19 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 				MessageID: "test-assistant-msg",
 				Role:      "assistant",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "data",
-						"data": map[string]any{
-							"tool_calls": []sdk.ChatCompletionMessageToolCall{
-								{
-									Id:   "call_123",
-									Type: sdk.ChatCompletionToolType("function"),
-									Function: sdk.ChatCompletionMessageToolCallFunction{
-										Name:      "test_tool",
-										Arguments: `{"param":"value"}`,
-									},
+					types.CreateDataPart(map[string]any{
+						"tool_calls": []sdk.ChatCompletionMessageToolCall{
+							{
+								Id:   "call_123",
+								Type: sdk.ChatCompletionToolType("function"),
+								Function: sdk.ChatCompletionMessageToolCallFunction{
+									Name:      "test_tool",
+									Arguments: `{"param":"value"}`,
 								},
 							},
-							"content": "I'll help you with that.",
 						},
-					},
+						"content": "I'll help you with that.",
+					}),
 				},
 			},
 			expectedToolCalls: &[]sdk.ChatCompletionMessageToolCall{
@@ -737,10 +587,7 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 				MessageID: "test-assistant-msg-2",
 				Role:      "assistant",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "text",
-						"text": "Hello, how can I help you?",
-					},
+					types.CreateTextPart("Hello, how can I help you?"),
 				},
 			},
 			expectedToolCalls: nil,
@@ -752,18 +599,15 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 				MessageID: "test-user-msg",
 				Role:      "user",
 				Parts: []types.Part{
-					map[string]any{
-						"kind": "data",
-						"data": map[string]any{
-							"tool_calls": []sdk.ChatCompletionMessageToolCall{
-								{
-									Id:   "call_456",
-									Type: sdk.ChatCompletionToolType("function"),
-								},
+					types.CreateDataPart(map[string]any{
+						"tool_calls": []sdk.ChatCompletionMessageToolCall{
+							{
+								Id:   "call_456",
+								Type: sdk.ChatCompletionToolType("function"),
 							},
-							"result": "User content",
 						},
-					},
+						"result": "User content",
+					}),
 				},
 			},
 			expectedToolCalls: nil,
@@ -801,46 +645,37 @@ func TestMessageConverter_ConvertToSDK_ToolCallsSequence(t *testing.T) {
 			MessageID: "user-msg",
 			Role:      "user",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "text",
-					"text": "What's on my calendar today?",
-				},
+				types.CreateTextPart("What's on my calendar today?"),
 			},
 		},
 		{
 			MessageID: "assistant-msg",
 			Role:      "assistant",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "data",
-					"data": map[string]any{
-						"tool_calls": []sdk.ChatCompletionMessageToolCall{
-							{
-								Id:   "call_0_2e5a532f-06e2-4ced-8434-31e25019e144",
-								Type: sdk.ChatCompletionToolType("function"),
-								Function: sdk.ChatCompletionMessageToolCallFunction{
-									Name:      "list_calendar_events",
-									Arguments: `{"start_date":"2025-06-16","end_date":"2025-06-16"}`,
-								},
+				types.CreateDataPart(map[string]any{
+					"tool_calls": []sdk.ChatCompletionMessageToolCall{
+						{
+							Id:   "call_0_2e5a532f-06e2-4ced-8434-31e25019e144",
+							Type: sdk.ChatCompletionToolType("function"),
+							Function: sdk.ChatCompletionMessageToolCallFunction{
+								Name:      "list_calendar_events",
+								Arguments: `{"start_date":"2025-06-16","end_date":"2025-06-16"}`,
 							},
 						},
-						"content": "",
 					},
-				},
+					"content": "",
+				}),
 			},
 		},
 		{
 			MessageID: "tool-result-msg",
 			Role:      "tool",
 			Parts: []types.Part{
-				map[string]any{
-					"kind": "data",
-					"data": map[string]any{
-						"tool_call_id": "call_0_2e5a532f-06e2-4ced-8434-31e25019e144",
-						"tool_name":    "list_calendar_events",
-						"result":       `{"message":"Found 0 events between 2025-06-16 00:00 and 2025-06-16 23:59","success":true}`,
-					},
-				},
+				types.CreateDataPart(map[string]any{
+					"tool_call_id": "call_0_2e5a532f-06e2-4ced-8434-31e25019e144",
+					"tool_name":    "list_calendar_events",
+					"result":       `{"message":"Found 0 events between 2025-06-16 00:00 and 2025-06-16 23:59","success":true}`,
+				}),
 			},
 		},
 	}

--- a/server/utils/message_converter_test.go
+++ b/server/utils/message_converter_test.go
@@ -24,7 +24,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert simple text message",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-1",
 					Role:      "user",
 					Parts: []types.Part{
@@ -47,7 +46,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert assistant message",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-2",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -70,7 +68,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert system message",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-3",
 					Role:      "system",
 					Parts: []types.Part{
@@ -93,7 +90,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert message with empty role defaults to user",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-4",
 					Role:      "",
 					Parts: []types.Part{
@@ -116,7 +112,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert message with multiple text parts",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-5",
 					Role:      "user",
 					Parts: []types.Part{
@@ -143,7 +138,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert message with data part",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-6",
 					Role:      "tool",
 					Parts: []types.Part{
@@ -174,7 +168,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert strongly-typed message part",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-7",
 					Role:      "user",
 					Parts: []types.Part{
@@ -197,7 +190,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert message with file part (no content extraction)",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-8",
 					Role:      "user",
 					Parts: []types.Part{
@@ -228,7 +220,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			name: "convert multiple messages",
 			input: []types.Message{
 				{
-					Kind:      "message",
 					MessageID: "test-msg-9",
 					Role:      "user",
 					Parts: []types.Part{
@@ -239,7 +230,6 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 					},
 				},
 				{
-					Kind:      "message",
 					MessageID: "test-msg-10",
 					Role:      "assistant",
 					Parts: []types.Part{
@@ -301,7 +291,6 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Kind: "message",
 				Role: "user",
 				Parts: []types.Part{
 					types.TextPart{
@@ -319,7 +308,6 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Kind: "message",
 				Role: "assistant",
 				Parts: []types.Part{
 					types.TextPart{
@@ -337,7 +325,6 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Kind: "message",
 				Role: "system",
 				Parts: []types.Part{
 					types.TextPart{
@@ -359,7 +346,6 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Kind: "message",
 				Role: "tool",
 				Parts: []types.Part{
 					types.DataPart{
@@ -394,7 +380,6 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Kind: "message",
 				Role: "assistant",
 				Parts: []types.Part{
 					types.TextPart{
@@ -427,7 +412,6 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Kind: "message",
 				Role: "assistant",
 				Parts: []types.Part{
 					types.TextPart{
@@ -645,7 +629,6 @@ func TestMessageConverter_RoundTrip(t *testing.T) {
 	converter := NewMessageConverter(logger)
 
 	originalMessage := types.Message{
-		Kind:      "message",
 		MessageID: "round-trip-test",
 		Role:      "user",
 		Parts: []types.Part{
@@ -680,7 +663,6 @@ func TestMessageConverter_PerformanceWithManyMessages(t *testing.T) {
 	messages := make([]types.Message, 1000)
 	for i := 0; i < 1000; i++ {
 		messages[i] = types.Message{
-			Kind:      "message",
 			MessageID: "perf-test-" + string(rune(i)),
 			Role:      "user",
 			Parts: []types.Part{
@@ -718,7 +700,6 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 			inputMessage: types.Message{
 				MessageID: "test-assistant-msg",
 				Role:      "assistant",
-				Kind:      "message",
 				Parts: []types.Part{
 					map[string]any{
 						"kind": "data",
@@ -755,7 +736,6 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 			inputMessage: types.Message{
 				MessageID: "test-assistant-msg-2",
 				Role:      "assistant",
-				Kind:      "message",
 				Parts: []types.Part{
 					map[string]any{
 						"kind": "text",
@@ -771,7 +751,6 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 			inputMessage: types.Message{
 				MessageID: "test-user-msg",
 				Role:      "user",
-				Kind:      "message",
 				Parts: []types.Part{
 					map[string]any{
 						"kind": "data",
@@ -821,7 +800,6 @@ func TestMessageConverter_ConvertToSDK_ToolCallsSequence(t *testing.T) {
 		{
 			MessageID: "user-msg",
 			Role:      "user",
-			Kind:      "message",
 			Parts: []types.Part{
 				map[string]any{
 					"kind": "text",
@@ -832,7 +810,6 @@ func TestMessageConverter_ConvertToSDK_ToolCallsSequence(t *testing.T) {
 		{
 			MessageID: "assistant-msg",
 			Role:      "assistant",
-			Kind:      "message",
 			Parts: []types.Part{
 				map[string]any{
 					"kind": "data",
@@ -855,7 +832,6 @@ func TestMessageConverter_ConvertToSDK_ToolCallsSequence(t *testing.T) {
 		{
 			MessageID: "tool-result-msg",
 			Role:      "tool",
-			Kind:      "message",
 			Parts: []types.Part{
 				map[string]any{
 					"kind": "data",

--- a/server/utils/message_converter_test.go
+++ b/server/utils/message_converter_test.go
@@ -25,7 +25,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			input: []types.Message{
 				{
 					MessageID: "test-msg-1",
-					Role:      "user",
+					Role:      types.RoleUser,
 					Parts: []types.Part{
 						types.CreateTextPart("Hello, world!"),
 					},
@@ -44,7 +44,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			input: []types.Message{
 				{
 					MessageID: "test-msg-2",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Hi there!"),
 					},
@@ -59,11 +59,11 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "convert system message",
+			name: "convert agent message treated as system-like (A2A doesn't have system role)",
 			input: []types.Message{
 				{
 					MessageID: "test-msg-3",
-					Role:      "system",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("You are a helpful assistant."),
 					},
@@ -71,7 +71,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			},
 			expectedOutput: []sdk.Message{
 				func() sdk.Message {
-					msg, _ := sdk.NewTextMessage(sdk.System, "You are a helpful assistant.")
+					msg, _ := sdk.NewTextMessage(sdk.Assistant, "You are a helpful assistant.")
 					return msg
 				}(),
 			},
@@ -101,7 +101,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			input: []types.Message{
 				{
 					MessageID: "test-msg-5",
-					Role:      "user",
+					Role:      types.RoleUser,
 					Parts: []types.Part{
 						types.CreateTextPart("Part 1. "),
 						types.CreateTextPart("Part 2."),
@@ -117,11 +117,11 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "convert message with data part",
+			name: "convert message with data part (A2A doesn't have tool role, uses agent with tool_call_id)",
 			input: []types.Message{
 				{
 					MessageID: "test-msg-6",
-					Role:      "tool",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateDataPart(map[string]any{
 							"tool_call_id": "call_test_function",
@@ -148,7 +148,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			input: []types.Message{
 				{
 					MessageID: "test-msg-7",
-					Role:      "user",
+					Role:      types.RoleUser,
 					Parts: []types.Part{
 						types.CreateTextPart("Strongly typed message"),
 					},
@@ -167,7 +167,7 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			input: []types.Message{
 				{
 					MessageID: "test-msg-8",
-					Role:      "user",
+					Role:      types.RoleUser,
 					Parts: []types.Part{
 						types.CreateTextPart("Please analyze this file: "),
 						types.CreateFilePart("test.txt", "text/plain", stringPtr("base64encodedcontent"), nil),
@@ -187,14 +187,14 @@ func TestMessageConverter_ConvertToSDK(t *testing.T) {
 			input: []types.Message{
 				{
 					MessageID: "test-msg-9",
-					Role:      "user",
+					Role:      types.RoleUser,
 					Parts: []types.Part{
 						types.CreateTextPart("First message"),
 					},
 				},
 				{
 					MessageID: "test-msg-10",
-					Role:      "assistant",
+					Role:      types.RoleAgent,
 					Parts: []types.Part{
 						types.CreateTextPart("Second message"),
 					},
@@ -251,7 +251,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Role: "user",
+				Role: types.RoleUser,
 				Parts: []types.Part{
 					types.CreateTextPart("Hello from SDK"),
 				},
@@ -265,7 +265,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Role: "assistant",
+				Role: types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Response from assistant"),
 				},
@@ -273,13 +273,13 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "convert SDK system message",
+			name: "convert SDK system message (A2A maps to agent role)",
 			input: func() sdk.Message {
 				msg, _ := sdk.NewTextMessage(sdk.System, "System instructions")
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Role: "system",
+				Role: types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("System instructions"),
 				},
@@ -287,7 +287,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "convert SDK tool message",
+			name: "convert SDK tool message (A2A maps to agent role)",
 			input: func() sdk.Message {
 				msg := sdk.Message{
 					Role:       sdk.Tool,
@@ -297,7 +297,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Role: "tool",
+				Role: types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateDataPart(map[string]any{
 						"tool_call_id": "call_123",
@@ -328,7 +328,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Role: "assistant",
+				Role: types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("I'll help you with that"),
 					types.CreateDataPart(map[string]any{
@@ -354,7 +354,7 @@ func TestMessageConverter_ConvertFromSDK(t *testing.T) {
 				return msg
 			}(),
 			expectedOutput: &types.Message{
-				Role: "assistant",
+				Role: types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart(""),
 				},
@@ -491,7 +491,7 @@ func TestMessageConverter_RoundTrip(t *testing.T) {
 
 	originalMessage := types.Message{
 		MessageID: "round-trip-test",
-		Role:      "user",
+		Role:      types.RoleUser,
 		Parts: []types.Part{
 			types.CreateTextPart("Round trip test message"),
 		},
@@ -520,7 +520,7 @@ func TestMessageConverter_PerformanceWithManyMessages(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		messages[i] = types.Message{
 			MessageID: "perf-test-" + string(rune(i)),
-			Role:      "user",
+			Role:      types.RoleUser,
 			Parts: []types.Part{
 				types.CreateTextPart("Performance test message number " + string(rune(i))),
 			},
@@ -552,7 +552,7 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 			name: "assistant message with tool_calls in data part",
 			inputMessage: types.Message{
 				MessageID: "test-assistant-msg",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateDataPart(map[string]any{
 						"tool_calls": []sdk.ChatCompletionMessageToolCall{
@@ -585,7 +585,7 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 			name: "assistant message with only content, no tool_calls",
 			inputMessage: types.Message{
 				MessageID: "test-assistant-msg-2",
-				Role:      "assistant",
+				Role:      types.RoleAgent,
 				Parts: []types.Part{
 					types.CreateTextPart("Hello, how can I help you?"),
 				},
@@ -597,7 +597,7 @@ func TestMessageConverter_ConvertToSDK_ToolCalls(t *testing.T) {
 			name: "user message with text (should not extract tool_calls)",
 			inputMessage: types.Message{
 				MessageID: "test-user-msg",
-				Role:      "user",
+				Role:      types.RoleUser,
 				Parts: []types.Part{
 					types.CreateDataPart(map[string]any{
 						"tool_calls": []sdk.ChatCompletionMessageToolCall{
@@ -643,14 +643,14 @@ func TestMessageConverter_ConvertToSDK_ToolCallsSequence(t *testing.T) {
 	messages := []types.Message{
 		{
 			MessageID: "user-msg",
-			Role:      "user",
+			Role:      types.RoleUser,
 			Parts: []types.Part{
 				types.CreateTextPart("What's on my calendar today?"),
 			},
 		},
 		{
 			MessageID: "assistant-msg",
-			Role:      "assistant",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateDataPart(map[string]any{
 					"tool_calls": []sdk.ChatCompletionMessageToolCall{
@@ -669,7 +669,7 @@ func TestMessageConverter_ConvertToSDK_ToolCallsSequence(t *testing.T) {
 		},
 		{
 			MessageID: "tool-result-msg",
-			Role:      "tool",
+			Role:      types.RoleAgent,
 			Parts: []types.Part{
 				types.CreateDataPart(map[string]any{
 					"tool_call_id": "call_0_2e5a532f-06e2-4ced-8434-31e25019e144",

--- a/types/generated_types.go
+++ b/types/generated_types.go
@@ -1,44 +1,13 @@
 // Code generated from JSON schema. DO NOT EDIT.
 package types
 
-// Defines the lifecycle states of a Task.
-type TaskState string
-
-// TaskState enum values
-const (
-	TaskStateAuthRequired  TaskState = "auth-required"
-	TaskStateCanceled      TaskState = "canceled"
-	TaskStateCompleted     TaskState = "completed"
-	TaskStateFailed        TaskState = "failed"
-	TaskStateInputRequired TaskState = "input-required"
-	TaskStateRejected      TaskState = "rejected"
-	TaskStateSubmitted     TaskState = "submitted"
-	TaskStateUnknown       TaskState = "unknown"
-	TaskStateWorking       TaskState = "working"
-)
-
-// Supported A2A transport protocols.
-type TransportProtocol string
-
-// TransportProtocol enum values
-const (
-	TransportProtocolGrpc     TransportProtocol = "GRPC"
-	TransportProtocolHttpjson TransportProtocol = "HTTP+JSON"
-	TransportProtocolJSONRPC  TransportProtocol = "JSONRPC"
-)
-
-// A discriminated union of all standard JSON-RPC and A2A-specific error types.
-type A2AError any
-
-// A discriminated union representing all possible JSON-RPC 2.0 requests supported by the A2A specification.
-type A2ARequest any
+import "time"
 
 // Defines a security scheme using an API key.
 type APIKeySecurityScheme struct {
 	Description *string `json:"description,omitempty"`
-	In          string  `json:"in"`
+	Location    string  `json:"location"`
 	Name        string  `json:"name"`
-	Type        string  `json:"type"`
 }
 
 // Defines optional capabilities supported by an agent.
@@ -49,51 +18,54 @@ type AgentCapabilities struct {
 	Streaming              *bool            `json:"streaming,omitempty"`
 }
 
-// The AgentCard is a self-describing manifest for an agent. It provides essential
+// AgentCard is a self-describing manifest for an agent. It provides essential
 // metadata including the agent's identity, capabilities, skills, supported
 // communication methods, and security requirements.
+// Next ID: 20
 type AgentCard struct {
-	AdditionalInterfaces              []AgentInterface          `json:"additionalInterfaces,omitempty"`
-	Capabilities                      AgentCapabilities         `json:"capabilities"`
-	DefaultInputModes                 []string                  `json:"defaultInputModes"`
-	DefaultOutputModes                []string                  `json:"defaultOutputModes"`
-	Description                       string                    `json:"description"`
-	DocumentationURL                  *string                   `json:"documentationUrl,omitempty"`
-	IconURL                           *string                   `json:"iconUrl,omitempty"`
-	Name                              string                    `json:"name"`
-	PreferredTransport                string                    `json:"preferredTransport,omitempty"`
-	ProtocolVersion                   string                    `json:"protocolVersion"`
-	Provider                          *AgentProvider            `json:"provider,omitempty"`
-	Security                          []map[string][]string     `json:"security,omitempty"`
-	SecuritySchemes                   map[string]SecurityScheme `json:"securitySchemes,omitempty"`
-	Signatures                        []AgentCardSignature      `json:"signatures,omitempty"`
-	Skills                            []AgentSkill              `json:"skills"`
-	SupportsAuthenticatedExtendedCard *bool                     `json:"supportsAuthenticatedExtendedCard,omitempty"`
-	URL                               string                    `json:"url"`
-	Version                           string                    `json:"version"`
+	AdditionalInterfaces      []AgentInterface          `json:"additionalInterfaces,omitempty"`
+	Capabilities              AgentCapabilities         `json:"capabilities"`
+	DefaultInputModes         []string                  `json:"defaultInputModes"`
+	DefaultOutputModes        []string                  `json:"defaultOutputModes"`
+	Description               string                    `json:"description"`
+	DocumentationURL          *string                   `json:"documentationUrl,omitempty"`
+	IconURL                   *string                   `json:"iconUrl,omitempty"`
+	Name                      string                    `json:"name"`
+	PreferredTransport        *string                   `json:"preferredTransport,omitempty"`
+	ProtocolVersion           string                    `json:"protocolVersion"`
+	Provider                  *AgentProvider            `json:"provider,omitempty"`
+	Security                  []Security                `json:"security,omitempty"`
+	SecuritySchemes           map[string]SecurityScheme `json:"securitySchemes,omitempty"`
+	Signatures                []AgentCardSignature      `json:"signatures,omitempty"`
+	Skills                    []AgentSkill              `json:"skills"`
+	SupportedInterfaces       []AgentInterface          `json:"supportedInterfaces,omitempty"`
+	SupportsExtendedAgentCard *bool                     `json:"supportsExtendedAgentCard,omitempty"`
+	URL                       *string                   `json:"url,omitempty"`
+	Version                   string                    `json:"version"`
 }
 
 // AgentCardSignature represents a JWS signature of an AgentCard.
 // This follows the JSON format of an RFC 7515 JSON Web Signature (JWS).
 type AgentCardSignature struct {
-	Header    map[string]any `json:"header,omitempty"`
-	Protected string         `json:"protected"`
-	Signature string         `json:"signature"`
+	Header    *Struct `json:"header,omitempty"`
+	Protected string  `json:"protected"`
+	Signature string  `json:"signature"`
 }
 
 // A declaration of a protocol extension supported by an Agent.
 type AgentExtension struct {
-	Description *string        `json:"description,omitempty"`
-	Params      map[string]any `json:"params,omitempty"`
-	Required    *bool          `json:"required,omitempty"`
-	URI         string         `json:"uri"`
+	Description string  `json:"description"`
+	Params      *Struct `json:"params,omitempty"`
+	Required    bool    `json:"required"`
+	URI         string  `json:"uri"`
 }
 
 // Declares a combination of a target URL and a transport protocol for interacting with the agent.
-// This allows agents to expose the same functionality over multiple transport mechanisms.
+// This allows agents to expose the same functionality over multiple protocol binding mechanisms.
 type AgentInterface struct {
-	Transport string `json:"transport"`
-	URL       string `json:"url"`
+	ProtocolBinding string  `json:"protocolBinding"`
+	Tenant          *string `json:"tenant,omitempty"`
+	URL             string  `json:"url"`
 }
 
 // Represents the service provider of an agent.
@@ -104,31 +76,30 @@ type AgentProvider struct {
 
 // Represents a distinct capability or function that an agent can perform.
 type AgentSkill struct {
-	Description string                `json:"description"`
-	Examples    []string              `json:"examples,omitempty"`
-	ID          string                `json:"id"`
-	InputModes  []string              `json:"inputModes,omitempty"`
-	Name        string                `json:"name"`
-	OutputModes []string              `json:"outputModes,omitempty"`
-	Security    []map[string][]string `json:"security,omitempty"`
-	Tags        []string              `json:"tags"`
+	Description string     `json:"description"`
+	Examples    []string   `json:"examples,omitempty"`
+	ID          string     `json:"id"`
+	InputModes  []string   `json:"inputModes,omitempty"`
+	Name        string     `json:"name"`
+	OutputModes []string   `json:"outputModes,omitempty"`
+	Security    []Security `json:"security,omitempty"`
+	Tags        []string   `json:"tags"`
 }
 
-// Represents a file, data structure, or other resource generated by an agent during a task.
+// Artifacts represent task outputs.
 type Artifact struct {
-	ArtifactID  string         `json:"artifactId"`
-	Description *string        `json:"description,omitempty"`
-	Extensions  []string       `json:"extensions,omitempty"`
-	Metadata    map[string]any `json:"metadata,omitempty"`
-	Name        *string        `json:"name,omitempty"`
-	Parts       []Part         `json:"parts"`
+	ArtifactID  string   `json:"artifactId"`
+	Description *string  `json:"description,omitempty"`
+	Extensions  []string `json:"extensions,omitempty"`
+	Metadata    *Struct  `json:"metadata,omitempty"`
+	Name        *string  `json:"name,omitempty"`
+	Parts       []Part   `json:"parts"`
 }
 
-// An A2A-specific error indicating that the agent does not have an Authenticated Extended Card configured
-type AuthenticatedExtendedCardNotConfiguredError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
+// Defines authentication details, used for push notifications.
+type AuthenticationInfo struct {
+	Credentials *string  `json:"credentials,omitempty"`
+	Schemes     []string `json:"schemes"`
 }
 
 // Defines configuration details for the OAuth 2.0 Authorization Code flow.
@@ -139,22 +110,10 @@ type AuthorizationCodeOAuthFlow struct {
 	TokenURL         string            `json:"tokenUrl"`
 }
 
-// Represents a JSON-RPC request for the `tasks/cancel` method.
+// Represents a request for the `tasks/cancel` method.
 type CancelTaskRequest struct {
-	ID      any          `json:"id"`
-	JSONRPC string       `json:"jsonrpc"`
-	Method  string       `json:"method"`
-	Params  TaskIdParams `json:"params"`
-}
-
-// Represents a JSON-RPC response for the `tasks/cancel` method.
-type CancelTaskResponse any
-
-// Represents a successful JSON-RPC response for the `tasks/cancel` method.
-type CancelTaskSuccessResponse struct {
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-	Result  Task   `json:"result"`
+	Name   string `json:"name"`
+	Tenant string `json:"tenant"`
 }
 
 // Defines configuration details for the OAuth 2.0 Client Credentials flow.
@@ -164,132 +123,42 @@ type ClientCredentialsOAuthFlow struct {
 	TokenURL   string            `json:"tokenUrl"`
 }
 
-// An A2A-specific error indicating an incompatibility between the requested
-// content types and the agent's capabilities.
-type ContentTypeNotSupportedError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// Represents a structured data segment (e.g., JSON) within a message or artifact.
+// DataPart represents a structured blob.
 type DataPart struct {
-	Data     map[string]any `json:"data"`
-	Kind     string         `json:"kind"`
-	Metadata map[string]any `json:"metadata,omitempty"`
+	Data Struct `json:"data"`
 }
 
-// Defines parameters for deleting a specific push notification configuration for a task.
-type DeleteTaskPushNotificationConfigParams struct {
-	ID                       string         `json:"id"`
-	Metadata                 map[string]any `json:"metadata,omitempty"`
-	PushNotificationConfigID string         `json:"pushNotificationConfigId"`
-}
-
-// Represents a JSON-RPC request for the `tasks/pushNotificationConfig/delete` method.
+// Represents a request for the `tasks/pushNotificationConfig/delete` method.
 type DeleteTaskPushNotificationConfigRequest struct {
-	ID      any                                    `json:"id"`
-	JSONRPC string                                 `json:"jsonrpc"`
-	Method  string                                 `json:"method"`
-	Params  DeleteTaskPushNotificationConfigParams `json:"params"`
+	Name   string `json:"name"`
+	Tenant string `json:"tenant"`
 }
 
-// Represents a JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.
-type DeleteTaskPushNotificationConfigResponse any
-
-// Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/delete` method.
-type DeleteTaskPushNotificationConfigSuccessResponse struct {
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-	Result  any    `json:"result"`
-}
-
-// Defines base properties for a file.
-type FileBase struct {
-	MIMEType *string `json:"mimeType,omitempty"`
-	Name     *string `json:"name,omitempty"`
-}
-
-// Represents a file segment within a message or artifact. The file content can be
-// provided either directly as bytes or as a URI.
+// FilePart represents the different ways files can be provided. If files are
+// small, directly feeding the bytes is supported via file_with_bytes. If the
+// file is large, the agent should read the content as appropriate directly
+// from the file_with_uri source.
 type FilePart struct {
-	File     any            `json:"file"`
-	Kind     string         `json:"kind"`
-	Metadata map[string]any `json:"metadata,omitempty"`
+	FileWithBytes *string `json:"fileWithBytes,omitempty"`
+	FileWithURI   *string `json:"fileWithUri,omitempty"`
+	MediaType     string  `json:"mediaType"`
+	Name          string  `json:"name"`
 }
 
-// Represents a file with its content provided directly as a base64-encoded string.
-type FileWithBytes struct {
-	Bytes    string  `json:"bytes"`
-	MIMEType *string `json:"mimeType,omitempty"`
-	Name     *string `json:"name,omitempty"`
+type GetExtendedAgentCardRequest struct {
+	Tenant string `json:"tenant"`
 }
 
-// Represents a file with its content located at a specific URI.
-type FileWithUri struct {
-	MIMEType *string `json:"mimeType,omitempty"`
-	Name     *string `json:"name,omitempty"`
-	URI      string  `json:"uri"`
-}
-
-// Represents a JSON-RPC request for the `agent/getAuthenticatedExtendedCard` method.
-type GetAuthenticatedExtendedCardRequest struct {
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-	Method  string `json:"method"`
-}
-
-// Represents a JSON-RPC response for the `agent/getAuthenticatedExtendedCard` method.
-type GetAuthenticatedExtendedCardResponse any
-
-// Represents a successful JSON-RPC response for the `agent/getAuthenticatedExtendedCard` method.
-type GetAuthenticatedExtendedCardSuccessResponse struct {
-	ID      any       `json:"id"`
-	JSONRPC string    `json:"jsonrpc"`
-	Result  AgentCard `json:"result"`
-}
-
-// Defines parameters for fetching a specific push notification configuration for a task.
-type GetTaskPushNotificationConfigParams struct {
-	ID                       string         `json:"id"`
-	Metadata                 map[string]any `json:"metadata,omitempty"`
-	PushNotificationConfigID *string        `json:"pushNotificationConfigId,omitempty"`
-}
-
-// Represents a JSON-RPC request for the `tasks/pushNotificationConfig/get` method.
 type GetTaskPushNotificationConfigRequest struct {
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-	Method  string `json:"method"`
-	Params  any    `json:"params"`
+	Name   string `json:"name"`
+	Tenant string `json:"tenant"`
 }
 
-// Represents a JSON-RPC response for the `tasks/pushNotificationConfig/get` method.
-type GetTaskPushNotificationConfigResponse any
-
-// Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/get` method.
-type GetTaskPushNotificationConfigSuccessResponse struct {
-	ID      any                        `json:"id"`
-	JSONRPC string                     `json:"jsonrpc"`
-	Result  TaskPushNotificationConfig `json:"result"`
-}
-
-// Represents a JSON-RPC request for the `tasks/get` method.
+// Represents a request for the `tasks/get` method.
 type GetTaskRequest struct {
-	ID      any             `json:"id"`
-	JSONRPC string          `json:"jsonrpc"`
-	Method  string          `json:"method"`
-	Params  TaskQueryParams `json:"params"`
-}
-
-// Represents a JSON-RPC response for the `tasks/get` method.
-type GetTaskResponse any
-
-// Represents a successful JSON-RPC response for the `tasks/get` method.
-type GetTaskSuccessResponse struct {
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-	Result  Task   `json:"result"`
+	HistoryLength *int    `json:"historyLength,omitempty"`
+	Name          string  `json:"name"`
+	Tenant        *string `json:"tenant,omitempty"`
 }
 
 // Defines a security scheme using HTTP authentication.
@@ -297,7 +166,6 @@ type HTTPAuthSecurityScheme struct {
 	BearerFormat *string `json:"bearerFormat,omitempty"`
 	Description  *string `json:"description,omitempty"`
 	Scheme       string  `json:"scheme"`
-	Type         string  `json:"type"`
 }
 
 // Defines configuration details for the OAuth 2.0 Implicit flow.
@@ -307,163 +175,61 @@ type ImplicitOAuthFlow struct {
 	Scopes           map[string]string `json:"scopes"`
 }
 
-// An error indicating an internal error on the server.
-type InternalError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// An A2A-specific error indicating that the agent returned a response that
-// does not conform to the specification for the current method.
-type InvalidAgentResponseError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// An error indicating that the method parameters are invalid.
-type InvalidParamsError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// An error indicating that the JSON sent is not a valid Request object.
-type InvalidRequestError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// An error indicating that the server received invalid JSON.
-type JSONParseError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// Represents a JSON-RPC 2.0 Error object, included in an error response.
-type JSONRPCError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// Represents a JSON-RPC 2.0 Error Response object.
-type JSONRPCErrorResponse struct {
-	Error   any    `json:"error"`
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-}
-
-// Defines the base structure for any JSON-RPC 2.0 request, response, or notification.
-type JSONRPCMessage struct {
-	ID      *any   `json:"id,omitempty"`
-	JSONRPC string `json:"jsonrpc"`
-}
-
-// Represents a JSON-RPC 2.0 Request object.
-type JSONRPCRequest struct {
-	ID      *any           `json:"id,omitempty"`
-	JSONRPC string         `json:"jsonrpc"`
-	Method  string         `json:"method"`
-	Params  map[string]any `json:"params,omitempty"`
-}
-
-// A discriminated union representing all possible JSON-RPC 2.0 responses
-// for the A2A specification methods.
-type JSONRPCResponse any
-
-// Represents a successful JSON-RPC 2.0 Response object.
-type JSONRPCSuccessResponse struct {
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-	Result  any    `json:"result"`
-}
-
-// Defines parameters for listing all push notification configurations associated with a task.
-type ListTaskPushNotificationConfigParams struct {
-	ID       string         `json:"id"`
-	Metadata map[string]any `json:"metadata,omitempty"`
-}
-
-// Represents a JSON-RPC request for the `tasks/pushNotificationConfig/list` method.
 type ListTaskPushNotificationConfigRequest struct {
-	ID      any                                  `json:"id"`
-	JSONRPC string                               `json:"jsonrpc"`
-	Method  string                               `json:"method"`
-	Params  ListTaskPushNotificationConfigParams `json:"params"`
+	PageSize  int    `json:"pageSize"`
+	PageToken string `json:"pageToken"`
+	Parent    string `json:"parent"`
+	Tenant    string `json:"tenant"`
 }
 
-// Represents a JSON-RPC response for the `tasks/pushNotificationConfig/list` method.
-type ListTaskPushNotificationConfigResponse any
-
-// Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/list` method.
-type ListTaskPushNotificationConfigSuccessResponse struct {
-	ID      any                          `json:"id"`
-	JSONRPC string                       `json:"jsonrpc"`
-	Result  []TaskPushNotificationConfig `json:"result"`
+// Represents a successful response for the `tasks/pushNotificationConfig/list`
+// method.
+type ListTaskPushNotificationConfigResponse struct {
+	Configs       []TaskPushNotificationConfig `json:"configs,omitempty"`
+	NextPageToken string                       `json:"nextPageToken"`
 }
 
-// JSON-RPC request model for the 'tasks/list' method.
+// Parameters for listing tasks with optional filtering criteria.
 type ListTasksRequest struct {
-	ID      any             `json:"id"`
-	JSONRPC string          `json:"jsonrpc"`
-	Method  string          `json:"method"`
-	Params  *TaskListParams `json:"params,omitempty"`
+	ContextID        string `json:"contextId"`
+	HistoryLength    *int   `json:"historyLength,omitempty"`
+	IncludeArtifacts *bool  `json:"includeArtifacts,omitempty"`
+	LastUpdatedAfter int    `json:"lastUpdatedAfter"`
+	PageSize         *int   `json:"pageSize,omitempty"`
+	PageToken        string `json:"pageToken"`
+	Status           string `json:"status"`
+	Tenant           string `json:"tenant"`
 }
 
-// JSON-RPC response for the 'tasks/list' method.
-type ListTasksResponse any
-
-// JSON-RPC success response for the 'tasks/list' method.
-type ListTasksSuccessResponse struct {
-	ID      any      `json:"id"`
-	JSONRPC string   `json:"jsonrpc"`
-	Result  TaskList `json:"result"`
+// Result object for tasks/list method containing an array of tasks and pagination information.
+type ListTasksResponse struct {
+	NextPageToken string `json:"nextPageToken"`
+	PageSize      int    `json:"pageSize"`
+	Tasks         []Task `json:"tasks"`
+	TotalSize     int    `json:"totalSize"`
 }
 
-// Represents a single message in the conversation between a user and an agent.
+// Message is one unit of communication between client and server. It is
+// associated with a context and optionally a task. Since the server is
+// responsible for the context definition, it must always provide a context_id
+// in its messages. The client can optionally provide the context_id if it
+// knows the context to associate the message to. Similarly for task_id,
+// except the server decides if a task is created and whether to include the
+// task_id.
 type Message struct {
-	ContextID        *string        `json:"contextId,omitempty"`
-	Extensions       []string       `json:"extensions,omitempty"`
-	Kind             string         `json:"kind"`
-	MessageID        string         `json:"messageId"`
-	Metadata         map[string]any `json:"metadata,omitempty"`
-	Parts            []Part         `json:"parts"`
-	ReferenceTaskIds []string       `json:"referenceTaskIds,omitempty"`
-	Role             string         `json:"role"`
-	TaskID           *string        `json:"taskId,omitempty"`
-}
-
-// Defines configuration options for a `message/send` or `message/stream` request.
-type MessageSendConfiguration struct {
-	AcceptedOutputModes    []string                `json:"acceptedOutputModes,omitempty"`
-	Blocking               *bool                   `json:"blocking,omitempty"`
-	HistoryLength          *int                    `json:"historyLength,omitempty"`
-	PushNotificationConfig *PushNotificationConfig `json:"pushNotificationConfig,omitempty"`
-}
-
-// Defines the parameters for a request to send a message to an agent. This can be used
-// to create a new task, continue an existing one, or restart a task.
-type MessageSendParams struct {
-	Configuration *MessageSendConfiguration `json:"configuration,omitempty"`
-	Message       Message                   `json:"message"`
-	Metadata      map[string]any            `json:"metadata,omitempty"`
-}
-
-// An error indicating that the requested method does not exist or is not available.
-type MethodNotFoundError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
+	ContextID        *string  `json:"contextId,omitempty"`
+	Extensions       []string `json:"extensions,omitempty"`
+	MessageID        string   `json:"messageId"`
+	Metadata         *Struct  `json:"metadata,omitempty"`
+	Parts            []Part   `json:"parts"`
+	ReferenceTaskIds []string `json:"referenceTaskIds,omitempty"`
+	Role             string   `json:"role"`
+	TaskID           *string  `json:"taskId,omitempty"`
 }
 
 // Defines a security scheme using mTLS authentication.
-type MutualTLSSecurityScheme struct {
-	Description *string `json:"description,omitempty"`
-	Type        string  `json:"type"`
+type MutualTlsSecurityScheme struct {
+	Description string `json:"description"`
 }
 
 // Defines a security scheme using OAuth 2.0.
@@ -471,7 +237,6 @@ type OAuth2SecurityScheme struct {
 	Description       *string    `json:"description,omitempty"`
 	Flows             OAuthFlows `json:"flows"`
 	Oauth2metadataURL *string    `json:"oauth2MetadataUrl,omitempty"`
-	Type              string     `json:"type"`
 }
 
 // Defines the configuration for the supported OAuth 2.0 flows.
@@ -486,16 +251,16 @@ type OAuthFlows struct {
 type OpenIdConnectSecurityScheme struct {
 	Description      *string `json:"description,omitempty"`
 	OpenIDConnectURL string  `json:"openIdConnectUrl"`
-	Type             string  `json:"type"`
 }
 
-// A discriminated union representing a part of a message or artifact, which can
-// be text, a file, or structured data.
-type Part any
-
-// Defines base properties common to all message or artifact parts.
-type PartBase struct {
-	Metadata map[string]any `json:"metadata,omitempty"`
+// Part represents a container for a section of communication content.
+// Parts can be purely textual, some sort of file (image, video, etc) or
+// a structured data blob (i.e. JSON).
+type Part struct {
+	Data     *DataPart `json:"data,omitempty"`
+	File     *FilePart `json:"file,omitempty"`
+	Metadata *Struct   `json:"metadata,omitempty"`
+	Text     *string   `json:"text,omitempty"`
 }
 
 // Defines configuration details for the OAuth 2.0 Resource Owner Password flow.
@@ -505,200 +270,128 @@ type PasswordOAuthFlow struct {
 	TokenURL   string            `json:"tokenUrl"`
 }
 
-// Defines authentication details for a push notification endpoint.
-type PushNotificationAuthenticationInfo struct {
-	Credentials *string  `json:"credentials,omitempty"`
-	Schemes     []string `json:"schemes"`
-}
-
-// Defines the configuration for setting up push notifications for task updates.
+// Configuration for setting up push notifications for task updates.
 type PushNotificationConfig struct {
-	Authentication *PushNotificationAuthenticationInfo `json:"authentication,omitempty"`
-	ID             *string                             `json:"id,omitempty"`
-	Token          *string                             `json:"token,omitempty"`
-	URL            string                              `json:"url"`
+	Authentication *AuthenticationInfo `json:"authentication,omitempty"`
+	ID             *string             `json:"id,omitempty"`
+	Token          *string             `json:"token,omitempty"`
+	URL            string              `json:"url"`
 }
 
-// An A2A-specific error indicating that the agent does not support push notifications.
-type PushNotificationNotSupportedError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
+type Security struct {
+	Schemes map[string]StringList `json:"schemes,omitempty"`
 }
 
 // Defines a security scheme that can be used to secure an agent's endpoints.
-// This is a discriminated union type based on the OpenAPI 3.0 Security Scheme Object.
-type SecurityScheme any
-
-// Defines base properties shared by all security scheme objects.
-type SecuritySchemeBase struct {
-	Description *string `json:"description,omitempty"`
+// This is a discriminated union type based on the OpenAPI 3.2 Security Scheme Object.
+// See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object
+type SecurityScheme struct {
+	APIKeySecurityScheme        *APIKeySecurityScheme        `json:"apiKeySecurityScheme,omitempty"`
+	HTTPAuthSecurityScheme      *HTTPAuthSecurityScheme      `json:"httpAuthSecurityScheme,omitempty"`
+	MtlsSecurityScheme          *MutualTlsSecurityScheme     `json:"mtlsSecurityScheme,omitempty"`
+	Oauth2securityScheme        *OAuth2SecurityScheme        `json:"oauth2SecurityScheme,omitempty"`
+	OpenIDConnectSecurityScheme *OpenIdConnectSecurityScheme `json:"openIdConnectSecurityScheme,omitempty"`
 }
 
-// Represents a JSON-RPC request for the `message/send` method.
+// Configuration of a send message request.
+type SendMessageConfiguration struct {
+	AcceptedOutputModes    []string                `json:"acceptedOutputModes,omitempty"`
+	Blocking               bool                    `json:"blocking"`
+	HistoryLength          *int                    `json:"historyLength,omitempty"`
+	PushNotificationConfig *PushNotificationConfig `json:"pushNotificationConfig,omitempty"`
+}
+
+// /////////// Request Messages ///////////
+// Represents a request for the `message/send` method.
 type SendMessageRequest struct {
-	ID      any               `json:"id"`
-	JSONRPC string            `json:"jsonrpc"`
-	Method  string            `json:"method"`
-	Params  MessageSendParams `json:"params"`
+	Configuration *SendMessageConfiguration `json:"configuration,omitempty"`
+	Message       *Message                  `json:"message,omitempty"`
+	Metadata      *Struct                   `json:"metadata,omitempty"`
+	Tenant        string                    `json:"tenant"`
 }
 
-// Represents a JSON-RPC response for the `message/send` method.
-type SendMessageResponse any
-
-// Represents a successful JSON-RPC response for the `message/send` method.
-type SendMessageSuccessResponse struct {
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-	Result  any    `json:"result"`
+// ////// Response Messages ///////////
+type SendMessageResponse struct {
+	Message *Message `json:"message,omitempty"`
+	Task    *Task    `json:"task,omitempty"`
 }
 
-// Represents a JSON-RPC request for the `message/stream` method.
-type SendStreamingMessageRequest struct {
-	ID      any               `json:"id"`
-	JSONRPC string            `json:"jsonrpc"`
-	Method  string            `json:"method"`
-	Params  MessageSendParams `json:"params"`
-}
-
-// Represents a JSON-RPC response for the `message/stream` method.
-type SendStreamingMessageResponse any
-
-// Represents a successful JSON-RPC response for the `message/stream` method.
-// The server may send multiple response objects for a single request.
-type SendStreamingMessageSuccessResponse struct {
-	ID      any    `json:"id"`
-	JSONRPC string `json:"jsonrpc"`
-	Result  any    `json:"result"`
-}
-
-// Represents a JSON-RPC request for the `tasks/pushNotificationConfig/set` method.
+// Represents a request for the `tasks/pushNotificationConfig/set` method.
 type SetTaskPushNotificationConfigRequest struct {
-	ID      any                        `json:"id"`
-	JSONRPC string                     `json:"jsonrpc"`
-	Method  string                     `json:"method"`
-	Params  TaskPushNotificationConfig `json:"params"`
+	Config   TaskPushNotificationConfig `json:"config"`
+	ConfigID string                     `json:"configId"`
+	Parent   string                     `json:"parent"`
+	Tenant   *string                    `json:"tenant,omitempty"`
 }
 
-// Represents a JSON-RPC response for the `tasks/pushNotificationConfig/set` method.
-type SetTaskPushNotificationConfigResponse any
-
-// Represents a successful JSON-RPC response for the `tasks/pushNotificationConfig/set` method.
-type SetTaskPushNotificationConfigSuccessResponse struct {
-	ID      any                        `json:"id"`
-	JSONRPC string                     `json:"jsonrpc"`
-	Result  TaskPushNotificationConfig `json:"result"`
+// A wrapper object used in streaming operations to encapsulate different types of response data.
+type StreamResponse struct {
+	ArtifactUpdate *TaskArtifactUpdateEvent `json:"artifactUpdate,omitempty"`
+	Message        *Message                 `json:"message,omitempty"`
+	StatusUpdate   *TaskStatusUpdateEvent   `json:"statusUpdate,omitempty"`
+	Task           *Task                    `json:"task,omitempty"`
 }
 
-// Represents a single, stateful operation or conversation between a client and an agent.
+// protolint:disable REPEATED_FIELD_NAMES_PLURALIZED
+type StringList struct {
+	List []string `json:"list,omitempty"`
+}
+
+type Struct struct {
+}
+
+type SubscribeToTaskRequest struct {
+	Name   string `json:"name"`
+	Tenant string `json:"tenant"`
+}
+
+// Task is the core unit of action for A2A. It has a current status
+// and when results are created for the task they are stored in the
+// artifact. If there are multiple turns for a task, these are stored in
+// history.
 type Task struct {
-	Artifacts []Artifact     `json:"artifacts,omitempty"`
-	ContextID string         `json:"contextId"`
-	History   []Message      `json:"history,omitempty"`
-	ID        string         `json:"id"`
-	Kind      string         `json:"kind"`
-	Metadata  map[string]any `json:"metadata,omitempty"`
-	Status    TaskStatus     `json:"status"`
+	Artifacts []Artifact `json:"artifacts,omitempty"`
+	ContextID string     `json:"contextId"`
+	History   []Message  `json:"history,omitempty"`
+	ID        string     `json:"id"`
+	Metadata  *Struct    `json:"metadata,omitempty"`
+	Status    TaskStatus `json:"status"`
 }
 
-// An event sent by the agent to notify the client that an artifact has been
-// generated or updated. This is typically used in streaming models.
+// TaskArtifactUpdateEvent represents a task delta where an artifact has
+// been generated.
 type TaskArtifactUpdateEvent struct {
-	Append    *bool          `json:"append,omitempty"`
-	Artifact  Artifact       `json:"artifact"`
-	ContextID string         `json:"contextId"`
-	Kind      string         `json:"kind"`
-	LastChunk *bool          `json:"lastChunk,omitempty"`
-	Metadata  map[string]any `json:"metadata,omitempty"`
-	TaskID    string         `json:"taskId"`
+	Append    *bool    `json:"append,omitempty"`
+	Artifact  Artifact `json:"artifact"`
+	ContextID string   `json:"contextId"`
+	LastChunk *bool    `json:"lastChunk,omitempty"`
+	Metadata  *Struct  `json:"metadata,omitempty"`
+	TaskID    string   `json:"taskId"`
 }
 
-// Defines parameters containing a task ID, used for simple task operations.
-type TaskIdParams struct {
-	ID       string         `json:"id"`
-	Metadata map[string]any `json:"metadata,omitempty"`
-}
-
-// List of tasks with pagination information.
-type TaskList struct {
-	Limit  int    `json:"limit"`
-	Offset int    `json:"offset"`
-	Tasks  []Task `json:"tasks"`
-	Total  int    `json:"total"`
-}
-
-// Parameters for listing tasks with optional filtering and pagination.
-type TaskListParams struct {
-	ContextID *string        `json:"contextId,omitempty"`
-	Limit     int            `json:"limit,omitempty"`
-	Metadata  map[string]any `json:"metadata,omitempty"`
-	Offset    int            `json:"offset,omitempty"`
-	State     *TaskState     `json:"state,omitempty"`
-}
-
-// An A2A-specific error indicating that the task is in a state where it cannot be canceled.
-type TaskNotCancelableError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// An A2A-specific error indicating that the requested task ID was not found.
-type TaskNotFoundError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
-}
-
-// A container associating a push notification configuration with a specific task.
+// A container associating a push notification configuration with a specific
+// task.
 type TaskPushNotificationConfig struct {
+	Name                   string                 `json:"name"`
 	PushNotificationConfig PushNotificationConfig `json:"pushNotificationConfig"`
-	TaskID                 string                 `json:"taskId"`
 }
 
-// Defines parameters for querying a task, with an option to limit history length.
-type TaskQueryParams struct {
-	HistoryLength *int           `json:"historyLength,omitempty"`
-	ID            string         `json:"id"`
-	Metadata      map[string]any `json:"metadata,omitempty"`
-}
-
-// Represents a JSON-RPC request for the `tasks/resubscribe` method, used to resume a streaming connection.
-type TaskResubscriptionRequest struct {
-	ID      any          `json:"id"`
-	JSONRPC string       `json:"jsonrpc"`
-	Method  string       `json:"method"`
-	Params  TaskIdParams `json:"params"`
-}
-
-// Represents the status of a task at a specific point in time.
+// A container for the status of a task
 type TaskStatus struct {
-	Message   *Message  `json:"message,omitempty"`
-	State     TaskState `json:"state"`
-	Timestamp *string   `json:"timestamp,omitempty"`
+	Message   *Message   `json:"message,omitempty"`
+	State     string     `json:"state"`
+	Timestamp *Timestamp `json:"timestamp,omitempty"`
 }
 
-// An event sent by the agent to notify the client of a change in a task's status.
-// This is typically used in streaming or subscription models.
+// An event sent by the agent to notify the client of a change in a task's
+// status.
 type TaskStatusUpdateEvent struct {
-	ContextID string         `json:"contextId"`
-	Final     bool           `json:"final"`
-	Kind      string         `json:"kind"`
-	Metadata  map[string]any `json:"metadata,omitempty"`
-	Status    TaskStatus     `json:"status"`
-	TaskID    string         `json:"taskId"`
+	ContextID string     `json:"contextId"`
+	Final     bool       `json:"final"`
+	Metadata  *Struct    `json:"metadata,omitempty"`
+	Status    TaskStatus `json:"status"`
+	TaskID    string     `json:"taskId"`
 }
 
-// Represents a text segment within a message or artifact.
-type TextPart struct {
-	Kind     string         `json:"kind"`
-	Metadata map[string]any `json:"metadata,omitempty"`
-	Text     string         `json:"text"`
-}
-
-// An A2A-specific error indicating that the requested operation is not supported by the agent.
-type UnsupportedOperationError struct {
-	Code    int    `json:"code"`
-	Data    *any   `json:"data,omitempty"`
-	Message string `json:"message"`
+type Timestamp struct {
 }

--- a/types/generated_types.go
+++ b/types/generated_types.go
@@ -1,8 +1,6 @@
 // Code generated from JSON schema. DO NOT EDIT.
 package types
 
-import "time"
-
 // Defines a security scheme using an API key.
 type APIKeySecurityScheme struct {
 	Description *string `json:"description,omitempty"`
@@ -337,8 +335,7 @@ type StringList struct {
 	List []string `json:"list,omitempty"`
 }
 
-type Struct struct {
-}
+type Struct = map[string]any
 
 type SubscribeToTaskRequest struct {
 	Name   string `json:"name"`

--- a/types/generated_types.go
+++ b/types/generated_types.go
@@ -1,6 +1,34 @@
 // Code generated from JSON schema. DO NOT EDIT.
 package types
 
+import "time"
+
+// Identifies the sender of the message.
+type Role string
+
+// Role enum values
+const (
+	RoleAgent       Role = "ROLE_AGENT"
+	RoleUnspecified Role = "ROLE_UNSPECIFIED"
+	RoleUser        Role = "ROLE_USER"
+)
+
+// The current state of this task.
+type TaskState string
+
+// TaskState enum values
+const (
+	TaskStateAuthRequired  TaskState = "TASK_STATE_AUTH_REQUIRED"
+	TaskStateCancelled     TaskState = "TASK_STATE_CANCELLED"
+	TaskStateCompleted     TaskState = "TASK_STATE_COMPLETED"
+	TaskStateFailed        TaskState = "TASK_STATE_FAILED"
+	TaskStateInputRequired TaskState = "TASK_STATE_INPUT_REQUIRED"
+	TaskStateRejected      TaskState = "TASK_STATE_REJECTED"
+	TaskStateSubmitted     TaskState = "TASK_STATE_SUBMITTED"
+	TaskStateUnspecified   TaskState = "TASK_STATE_UNSPECIFIED"
+	TaskStateWorking       TaskState = "TASK_STATE_WORKING"
+)
+
 // Defines a security scheme using an API key.
 type APIKeySecurityScheme struct {
 	Description *string `json:"description,omitempty"`
@@ -189,14 +217,14 @@ type ListTaskPushNotificationConfigResponse struct {
 
 // Parameters for listing tasks with optional filtering criteria.
 type ListTasksRequest struct {
-	ContextID        string `json:"contextId"`
-	HistoryLength    *int   `json:"historyLength,omitempty"`
-	IncludeArtifacts *bool  `json:"includeArtifacts,omitempty"`
-	LastUpdatedAfter int    `json:"lastUpdatedAfter"`
-	PageSize         *int   `json:"pageSize,omitempty"`
-	PageToken        string `json:"pageToken"`
-	Status           string `json:"status"`
-	Tenant           string `json:"tenant"`
+	ContextID        string    `json:"contextId"`
+	HistoryLength    *int      `json:"historyLength,omitempty"`
+	IncludeArtifacts *bool     `json:"includeArtifacts,omitempty"`
+	LastUpdatedAfter int       `json:"lastUpdatedAfter"`
+	PageSize         *int      `json:"pageSize,omitempty"`
+	PageToken        string    `json:"pageToken"`
+	Status           TaskState `json:"status"`
+	Tenant           string    `json:"tenant"`
 }
 
 // Result object for tasks/list method containing an array of tasks and pagination information.
@@ -221,7 +249,7 @@ type Message struct {
 	Metadata         *Struct  `json:"metadata,omitempty"`
 	Parts            []Part   `json:"parts"`
 	ReferenceTaskIds []string `json:"referenceTaskIds,omitempty"`
-	Role             string   `json:"role"`
+	Role             Role     `json:"role"`
 	TaskID           *string  `json:"taskId,omitempty"`
 }
 
@@ -376,7 +404,7 @@ type TaskPushNotificationConfig struct {
 // A container for the status of a task
 type TaskStatus struct {
 	Message   *Message   `json:"message,omitempty"`
-	State     string     `json:"state"`
+	State     TaskState  `json:"state"`
 	Timestamp *Timestamp `json:"timestamp,omitempty"`
 }
 
@@ -390,5 +418,4 @@ type TaskStatusUpdateEvent struct {
 	TaskID    string     `json:"taskId"`
 }
 
-type Timestamp struct {
-}
+type Timestamp = time.Time

--- a/types/message_utils.go
+++ b/types/message_utils.go
@@ -10,17 +10,17 @@ import (
 // NewToolResultMessage creates a standardized tool result message
 func NewToolResultMessage(toolCallID string, toolName string, result any, hasError bool) *Message {
 	return &Message{
-		Kind:      "message",
 		MessageID: fmt.Sprintf("tool-result-%s", toolCallID),
 		Role:      "tool",
 		Parts: []Part{
-			map[string]any{
-				"kind": "data",
-				"data": map[string]any{
-					"tool_call_id": toolCallID,
-					"tool_name":    toolName,
-					"result":       result,
-					"error":        hasError,
+			{
+				Data: &DataPart{
+					Data: Struct{
+						"tool_call_id": toolCallID,
+						"tool_name":    toolName,
+						"result":       result,
+						"error":        hasError,
+					},
 				},
 			},
 		},
@@ -30,7 +30,6 @@ func NewToolResultMessage(toolCallID string, toolName string, result any, hasErr
 // NewAssistantMessage creates a standardized assistant message
 func NewAssistantMessage(messageID string, parts []Part) *Message {
 	return &Message{
-		Kind:      "message",
 		MessageID: messageID,
 		Role:      "assistant",
 		Parts:     parts,
@@ -39,35 +38,38 @@ func NewAssistantMessage(messageID string, parts []Part) *Message {
 
 // NewTextPart creates a text part for a message
 func NewTextPart(text string) Part {
-	return map[string]any{
-		"kind": "text",
-		"text": text,
+	return Part{
+		Text: &text,
 	}
 }
 
 // NewToolCallPart creates a tool call part for a message
 func NewToolCallPart(toolCallID, toolName string, arguments map[string]any) Part {
-	return map[string]any{
-		"kind": "tool_call",
-		"tool_call": map[string]any{
-			"id":        toolCallID,
-			"name":      toolName,
-			"arguments": arguments,
+	return Part{
+		Data: &DataPart{
+			Data: Struct{
+				"tool_call": map[string]any{
+					"id":        toolCallID,
+					"name":      toolName,
+					"arguments": arguments,
+				},
+			},
 		},
 	}
 }
 
 // NewDataPart creates a generic data part for a message
 func NewDataPart(data map[string]any) Part {
-	return map[string]any{
-		"kind": "data",
-		"data": data,
+	return Part{
+		Data: &DataPart{
+			Data: Struct(data),
+		},
 	}
 }
 
 // NewStreamingStatusMessage creates a status message for streaming
 func NewStreamingStatusMessage(messageID, status string, metadata map[string]any) *Message {
-	data := map[string]any{
+	data := Struct{
 		"status": status,
 	}
 	for k, v := range metadata {
@@ -75,7 +77,6 @@ func NewStreamingStatusMessage(messageID, status string, metadata map[string]any
 	}
 
 	return &Message{
-		Kind:      "message",
 		MessageID: messageID,
 		Role:      "assistant",
 		Parts: []Part{
@@ -87,7 +88,6 @@ func NewStreamingStatusMessage(messageID, status string, metadata map[string]any
 // NewInputRequiredMessage creates an input required message
 func NewInputRequiredMessage(toolCallID, message string) *Message {
 	return &Message{
-		Kind:      "input_required",
 		MessageID: fmt.Sprintf("input-required-%s", toolCallID),
 		Role:      "assistant",
 		Parts: []Part{

--- a/types/message_utils.go
+++ b/types/message_utils.go
@@ -15,7 +15,7 @@ func NewToolResultMessage(toolCallID string, toolName string, result any, hasErr
 		Parts: []Part{
 			{
 				Data: &DataPart{
-					Data: Struct{
+					Data: map[string]any{
 						"tool_call_id": toolCallID,
 						"tool_name":    toolName,
 						"result":       result,
@@ -47,7 +47,7 @@ func NewTextPart(text string) Part {
 func NewToolCallPart(toolCallID, toolName string, arguments map[string]any) Part {
 	return Part{
 		Data: &DataPart{
-			Data: Struct{
+			Data: map[string]any{
 				"tool_call": map[string]any{
 					"id":        toolCallID,
 					"name":      toolName,
@@ -62,14 +62,14 @@ func NewToolCallPart(toolCallID, toolName string, arguments map[string]any) Part
 func NewDataPart(data map[string]any) Part {
 	return Part{
 		Data: &DataPart{
-			Data: Struct(data),
+			Data: data,
 		},
 	}
 }
 
 // NewStreamingStatusMessage creates a status message for streaming
 func NewStreamingStatusMessage(messageID, status string, metadata map[string]any) *Message {
-	data := Struct{
+	data := map[string]any{
 		"status": status,
 	}
 	for k, v := range metadata {

--- a/types/message_utils.go
+++ b/types/message_utils.go
@@ -31,7 +31,7 @@ func NewToolResultMessage(toolCallID string, toolName string, result any, hasErr
 func NewAssistantMessage(messageID string, parts []Part) *Message {
 	return &Message{
 		MessageID: messageID,
-		Role:      "assistant",
+		Role:      RoleAgent,
 		Parts:     parts,
 	}
 }
@@ -78,7 +78,7 @@ func NewStreamingStatusMessage(messageID, status string, metadata map[string]any
 
 	return &Message{
 		MessageID: messageID,
-		Role:      "assistant",
+		Role:      RoleAgent,
 		Parts: []Part{
 			NewDataPart(data),
 		},
@@ -89,7 +89,7 @@ func NewStreamingStatusMessage(messageID, status string, metadata map[string]any
 func NewInputRequiredMessage(toolCallID, message string) *Message {
 	return &Message{
 		MessageID: fmt.Sprintf("input-required-%s", toolCallID),
-		Role:      "assistant",
+		Role:      RoleAgent,
 		Parts: []Part{
 			NewTextPart(message),
 		},

--- a/types/part_marshaling.go
+++ b/types/part_marshaling.go
@@ -79,34 +79,41 @@ func MarshalParts(parts []Part) ([]byte, error) {
 }
 
 // CreateTextPart creates a Part with text content
-func CreateTextPart(text string, metadata ...*Struct) Part {
+func CreateTextPart(text string, metadata ...map[string]any) Part {
 	part := Part{
 		Text: &text,
 	}
 	if len(metadata) > 0 {
-		part.Metadata = metadata[0]
+		part.Metadata = &metadata[0]
 	}
 	return part
 }
 
 // CreateDataPart creates a Part with data content
-func CreateDataPart(data *DataPart, metadata ...*Struct) Part {
+func CreateDataPart(data map[string]any, metadata ...map[string]any) Part {
 	part := Part{
-		Data: data,
+		Data: &DataPart{
+			Data: data,
+		},
 	}
 	if len(metadata) > 0 {
-		part.Metadata = metadata[0]
+		part.Metadata = &metadata[0]
 	}
 	return part
 }
 
 // CreateFilePart creates a Part with file content
-func CreateFilePart(file *FilePart, metadata ...*Struct) Part {
+func CreateFilePart(name, mediaType string, fileWithBytes *string, fileWithURI *string, metadata ...map[string]any) Part {
 	part := Part{
-		File: file,
+		File: &FilePart{
+			Name:          name,
+			MediaType:     mediaType,
+			FileWithBytes: fileWithBytes,
+			FileWithURI:   fileWithURI,
+		},
 	}
 	if len(metadata) > 0 {
-		part.Metadata = metadata[0]
+		part.Metadata = &metadata[0]
 	}
 	return part
 }

--- a/types/part_marshaling.go
+++ b/types/part_marshaling.go
@@ -39,7 +39,7 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	m.Metadata = helper.Metadata
 	m.Parts = parts
 	m.ReferenceTaskIds = helper.ReferenceTaskIds
-	m.Role = helper.Role
+	m.Role = Role(helper.Role)
 	m.TaskID = helper.TaskID
 
 	return nil

--- a/types/part_marshaling_test.go
+++ b/types/part_marshaling_test.go
@@ -63,13 +63,13 @@ func TestMarshalPart(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "marshal text part",
-			part: CreateTextPart("Hello, world!"),
+			name:     "marshal text part",
+			part:     CreateTextPart("Hello, world!"),
 			expected: `{"text":"Hello, world!"}`,
 		},
 		{
-			name: "marshal data part",
-			part: CreateDataPart(map[string]any{"result": "success"}),
+			name:     "marshal data part",
+			part:     CreateDataPart(map[string]any{"result": "success"}),
 			expected: `{"data":{"data":{"result":"success"}}}`,
 		},
 		{
@@ -239,7 +239,7 @@ func TestMessageUnmarshalJSON(t *testing.T) {
 			}`,
 			validate: func(t *testing.T, msg Message) {
 				assert.Equal(t, "msg-123", msg.MessageID)
-				assert.Equal(t, "user", msg.Role)
+				assert.Equal(t, Role("user"), msg.Role)
 				require.Len(t, msg.Parts, 2)
 
 				require.NotNil(t, msg.Parts[0].Text)
@@ -261,7 +261,7 @@ func TestMessageUnmarshalJSON(t *testing.T) {
 				]
 			}`,
 			validate: func(t *testing.T, msg Message) {
-				assert.Equal(t, "assistant", msg.Role)
+				assert.Equal(t, Role("assistant"), msg.Role)
 				require.Len(t, msg.Parts, 3)
 
 				require.NotNil(t, msg.Parts[0].Text)

--- a/types/part_marshaling_test.go
+++ b/types/part_marshaling_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
 )
 
 func TestUnmarshalPart(t *testing.T) {
@@ -253,7 +253,7 @@ func TestMessageUnmarshalJSON(t *testing.T) {
 			name: "message with mixed part types",
 			jsonData: `{
 				"messageId": "msg-456",
-				"role": "assistant",
+				"role": "ROLE_AGENT",
 				"parts": [
 					{"text": "Response"},
 					{"data": {"data": {"result": "success"}}},
@@ -261,7 +261,7 @@ func TestMessageUnmarshalJSON(t *testing.T) {
 				]
 			}`,
 			validate: func(t *testing.T, msg Message) {
-				assert.Equal(t, Role("assistant"), msg.Role)
+				assert.Equal(t, RoleAgent, msg.Role)
 				require.Len(t, msg.Parts, 3)
 
 				require.NotNil(t, msg.Parts[0].Text)
@@ -278,7 +278,7 @@ func TestMessageUnmarshalJSON(t *testing.T) {
 			name: "message round-trip with typed parts",
 			jsonData: `{
 				"messageId": "msg-789",
-				"role": "user",
+				"role": "ROLE_USER",
 				"parts": [
 					{"text": "Test message", "metadata": {"key": "value"}}
 				]

--- a/types/part_marshaling_test.go
+++ b/types/part_marshaling_test.go
@@ -12,44 +12,37 @@ func TestUnmarshalPart(t *testing.T) {
 	tests := []struct {
 		name     string
 		jsonData string
-		expected Part
+		validate func(t *testing.T, part Part)
 	}{
 		{
-			name:     "unmarshal TextPart",
-			jsonData: `{"kind": "text", "text": "Hello, world!", "metadata": {"key": "value"}}`,
-			expected: TextPart{
-				Kind:     "text",
-				Text:     "Hello, world!",
-				Metadata: map[string]any{"key": "value"},
+			name:     "unmarshal text part",
+			jsonData: `{"text": "Hello, world!", "metadata": {"key": "value"}}`,
+			validate: func(t *testing.T, part Part) {
+				require.NotNil(t, part.Text)
+				assert.Equal(t, "Hello, world!", *part.Text)
+				require.NotNil(t, part.Metadata)
+				assert.Equal(t, map[string]any{"key": "value"}, *part.Metadata)
 			},
 		},
 		{
-			name:     "unmarshal DataPart",
-			jsonData: `{"kind": "data", "data": {"result": "success"}, "metadata": {"source": "test"}}`,
-			expected: DataPart{
-				Kind:     "data",
-				Data:     map[string]any{"result": "success"},
-				Metadata: map[string]any{"source": "test"},
+			name:     "unmarshal data part",
+			jsonData: `{"data": {"data": {"result": "success"}}, "metadata": {"source": "test"}}`,
+			validate: func(t *testing.T, part Part) {
+				require.NotNil(t, part.Data)
+				assert.Equal(t, map[string]any{"result": "success"}, part.Data.Data)
+				require.NotNil(t, part.Metadata)
+				assert.Equal(t, map[string]any{"source": "test"}, *part.Metadata)
 			},
 		},
 		{
-			name:     "unmarshal FilePart with FileWithBytes",
-			jsonData: `{"kind": "file", "file": {"name": "test.txt", "mimeType": "text/plain", "bytes": "dGVzdA=="}}`,
-			expected: FilePart{
-				Kind: "file",
-				File: map[string]any{
-					"name":     "test.txt",
-					"mimeType": "text/plain",
-					"bytes":    "dGVzdA==",
-				},
-			},
-		},
-		{
-			name:     "unmarshal unknown kind as map",
-			jsonData: `{"kind": "unknown", "customField": "value"}`,
-			expected: map[string]any{
-				"kind":        "unknown",
-				"customField": "value",
+			name:     "unmarshal file part",
+			jsonData: `{"file": {"name": "test.txt", "mediaType": "text/plain", "fileWithBytes": "dGVzdA=="}}`,
+			validate: func(t *testing.T, part Part) {
+				require.NotNil(t, part.File)
+				assert.Equal(t, "test.txt", part.File.Name)
+				assert.Equal(t, "text/plain", part.File.MediaType)
+				require.NotNil(t, part.File.FileWithBytes)
+				assert.Equal(t, "dGVzdA==", *part.File.FileWithBytes)
 			},
 		},
 	}
@@ -58,7 +51,7 @@ func TestUnmarshalPart(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			part, err := UnmarshalPart([]byte(tt.jsonData))
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, part)
+			tt.validate(t, part)
 		})
 	}
 }
@@ -70,31 +63,22 @@ func TestMarshalPart(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "marshal TextPart",
-			part: TextPart{
-				Kind: "text",
-				Text: "Hello, world!",
-			},
-			expected: `{"kind":"text","text":"Hello, world!"}`,
+			name: "marshal text part",
+			part: CreateTextPart("Hello, world!"),
+			expected: `{"text":"Hello, world!"}`,
 		},
 		{
-			name: "marshal DataPart",
-			part: DataPart{
-				Kind: "data",
-				Data: map[string]any{"result": "success"},
-			},
-			expected: `{"kind":"data","data":{"result":"success"}}`,
+			name: "marshal data part",
+			part: CreateDataPart(map[string]any{"result": "success"}),
+			expected: `{"data":{"data":{"result":"success"}}}`,
 		},
 		{
-			name: "marshal FilePart",
-			part: FilePart{
-				Kind: "file",
-				File: map[string]any{
-					"name":     "test.txt",
-					"mimeType": "text/plain",
-				},
-			},
-			expected: `{"kind":"file","file":{"mimeType":"text/plain","name":"test.txt"}}`,
+			name: "marshal file part",
+			part: func() Part {
+				bytes := "dGVzdA=="
+				return CreateFilePart("test.txt", "text/plain", &bytes, nil)
+			}(),
+			expected: `{"file":{"name":"test.txt","mediaType":"text/plain","fileWithBytes":"dGVzdA=="}}`,
 		},
 	}
 
@@ -109,45 +93,45 @@ func TestMarshalPart(t *testing.T) {
 
 func TestUnmarshalParts(t *testing.T) {
 	jsonData := `[
-		{"kind": "text", "text": "Hello"},
-		{"kind": "data", "data": {"key": "value"}},
-		{"kind": "file", "file": {"name": "test.txt"}}
+		{"text": "Hello"},
+		{"data": {"data": {"key": "value"}}},
+		{"file": {"name": "test.txt", "mediaType": "text/plain"}}
 	]`
 
 	parts, err := UnmarshalParts([]byte(jsonData))
 	require.NoError(t, err)
 	require.Len(t, parts, 3)
 
-	textPart, ok := parts[0].(TextPart)
-	require.True(t, ok)
-	assert.Equal(t, "text", textPart.Kind)
-	assert.Equal(t, "Hello", textPart.Text)
+	// First part should be text
+	require.NotNil(t, parts[0].Text)
+	assert.Equal(t, "Hello", *parts[0].Text)
 
-	dataPart, ok := parts[1].(DataPart)
-	require.True(t, ok)
-	assert.Equal(t, "data", dataPart.Kind)
-	assert.Equal(t, map[string]any{"key": "value"}, dataPart.Data)
+	// Second part should be data
+	require.NotNil(t, parts[1].Data)
+	assert.Equal(t, map[string]any{"key": "value"}, parts[1].Data.Data)
 
-	filePart, ok := parts[2].(FilePart)
-	require.True(t, ok)
-	assert.Equal(t, "file", filePart.Kind)
-	assert.Equal(t, map[string]any{"name": "test.txt"}, filePart.File)
+	// Third part should be file
+	require.NotNil(t, parts[2].File)
+	assert.Equal(t, "test.txt", parts[2].File.Name)
+	assert.Equal(t, "text/plain", parts[2].File.MediaType)
 }
 
 func TestMarshalParts(t *testing.T) {
 	parts := []Part{
-		TextPart{Kind: "text", Text: "Hello"},
-		DataPart{Kind: "data", Data: map[string]any{"key": "value"}},
-		FilePart{Kind: "file", File: map[string]any{"name": "test.txt"}},
+		CreateTextPart("Hello"),
+		CreateDataPart(map[string]any{"key": "value"}),
+		func() Part {
+			return CreateFilePart("test.txt", "text/plain", nil, nil)
+		}(),
 	}
 
 	result, err := MarshalParts(parts)
 	require.NoError(t, err)
 
 	expected := `[
-		{"kind":"text","text":"Hello"},
-		{"kind":"data","data":{"key":"value"}},
-		{"kind":"file","file":{"name":"test.txt"}}
+		{"text":"Hello"},
+		{"data":{"data":{"key":"value"}}},
+		{"file":{"name":"test.txt","mediaType":"text/plain"}}
 	]`
 
 	assert.JSONEq(t, expected, string(result))
@@ -155,50 +139,57 @@ func TestMarshalParts(t *testing.T) {
 
 func TestCreateTextPart(t *testing.T) {
 	part := CreateTextPart("Hello, world!")
-	assert.Equal(t, "text", part.Kind)
-	assert.Equal(t, "Hello, world!", part.Text)
+	require.NotNil(t, part.Text)
+	assert.Equal(t, "Hello, world!", *part.Text)
 	assert.Nil(t, part.Metadata)
 
 	metadata := map[string]any{"key": "value"}
 	partWithMeta := CreateTextPart("Hello", metadata)
-	assert.Equal(t, "text", partWithMeta.Kind)
-	assert.Equal(t, "Hello", partWithMeta.Text)
-	assert.Equal(t, metadata, partWithMeta.Metadata)
+	require.NotNil(t, partWithMeta.Text)
+	assert.Equal(t, "Hello", *partWithMeta.Text)
+	require.NotNil(t, partWithMeta.Metadata)
+	assert.Equal(t, metadata, *partWithMeta.Metadata)
 }
 
 func TestCreateDataPart(t *testing.T) {
 	data := map[string]any{"result": "success"}
 	part := CreateDataPart(data)
-	assert.Equal(t, "data", part.Kind)
-	assert.Equal(t, data, part.Data)
+	require.NotNil(t, part.Data)
+	assert.Equal(t, data, part.Data.Data)
 	assert.Nil(t, part.Metadata)
 
 	metadata := map[string]any{"source": "test"}
 	partWithMeta := CreateDataPart(data, metadata)
-	assert.Equal(t, "data", partWithMeta.Kind)
-	assert.Equal(t, data, partWithMeta.Data)
-	assert.Equal(t, metadata, partWithMeta.Metadata)
+	require.NotNil(t, partWithMeta.Data)
+	assert.Equal(t, data, partWithMeta.Data.Data)
+	require.NotNil(t, partWithMeta.Metadata)
+	assert.Equal(t, metadata, *partWithMeta.Metadata)
 }
 
 func TestCreateFilePart(t *testing.T) {
-	file := map[string]any{"name": "test.txt", "mimeType": "text/plain"}
-	part := CreateFilePart(file)
-	assert.Equal(t, "file", part.Kind)
-	assert.Equal(t, file, part.File)
+	bytes := "dGVzdA=="
+	part := CreateFilePart("test.txt", "text/plain", &bytes, nil)
+	require.NotNil(t, part.File)
+	assert.Equal(t, "test.txt", part.File.Name)
+	assert.Equal(t, "text/plain", part.File.MediaType)
+	require.NotNil(t, part.File.FileWithBytes)
+	assert.Equal(t, bytes, *part.File.FileWithBytes)
 	assert.Nil(t, part.Metadata)
 
 	metadata := map[string]any{"uploaded": true}
-	partWithMeta := CreateFilePart(file, metadata)
-	assert.Equal(t, "file", partWithMeta.Kind)
-	assert.Equal(t, file, partWithMeta.File)
-	assert.Equal(t, metadata, partWithMeta.Metadata)
+	partWithMeta := CreateFilePart("test.txt", "text/plain", &bytes, nil, metadata)
+	require.NotNil(t, partWithMeta.File)
+	assert.Equal(t, "test.txt", partWithMeta.File.Name)
+	require.NotNil(t, partWithMeta.Metadata)
+	assert.Equal(t, metadata, *partWithMeta.Metadata)
 }
 
 func TestPartMarshalingRoundTrip(t *testing.T) {
+	bytes := "dGVzdA=="
 	original := []Part{
-		TextPart{Kind: "text", Text: "Hello, world!", Metadata: map[string]any{"lang": "en"}},
-		DataPart{Kind: "data", Data: map[string]any{"result": "success"}, Metadata: map[string]any{"source": "api"}},
-		FilePart{Kind: "file", File: map[string]any{"name": "test.txt", "bytes": "dGVzdA=="}, Metadata: map[string]any{"size": 4}},
+		CreateTextPart("Hello, world!", map[string]any{"lang": "en"}),
+		CreateDataPart(map[string]any{"result": "success"}, map[string]any{"source": "api"}),
+		CreateFilePart("test.txt", "text/plain", &bytes, nil, map[string]any{"size": 4}),
 	}
 
 	marshaled, err := MarshalParts(original)
@@ -209,23 +200,25 @@ func TestPartMarshalingRoundTrip(t *testing.T) {
 
 	require.Len(t, unmarshaled, 3)
 
-	textPart, ok := unmarshaled[0].(TextPart)
-	require.True(t, ok)
-	assert.Equal(t, "text", textPart.Kind)
-	assert.Equal(t, "Hello, world!", textPart.Text)
-	assert.Equal(t, map[string]any{"lang": "en"}, textPart.Metadata)
+	// Text part
+	require.NotNil(t, unmarshaled[0].Text)
+	assert.Equal(t, "Hello, world!", *unmarshaled[0].Text)
+	require.NotNil(t, unmarshaled[0].Metadata)
+	assert.Equal(t, map[string]any{"lang": "en"}, *unmarshaled[0].Metadata)
 
-	dataPart, ok := unmarshaled[1].(DataPart)
-	require.True(t, ok)
-	assert.Equal(t, "data", dataPart.Kind)
-	assert.Equal(t, map[string]any{"result": "success"}, dataPart.Data)
-	assert.Equal(t, map[string]any{"source": "api"}, dataPart.Metadata)
+	// Data part
+	require.NotNil(t, unmarshaled[1].Data)
+	assert.Equal(t, map[string]any{"result": "success"}, unmarshaled[1].Data.Data)
+	require.NotNil(t, unmarshaled[1].Metadata)
+	assert.Equal(t, map[string]any{"source": "api"}, *unmarshaled[1].Metadata)
 
-	filePart, ok := unmarshaled[2].(FilePart)
-	require.True(t, ok)
-	assert.Equal(t, "file", filePart.Kind)
-	assert.Equal(t, map[string]any{"name": "test.txt", "bytes": "dGVzdA=="}, filePart.File)
-	assert.Equal(t, map[string]any{"size": float64(4)}, filePart.Metadata)
+	// File part
+	require.NotNil(t, unmarshaled[2].File)
+	assert.Equal(t, "test.txt", unmarshaled[2].File.Name)
+	require.NotNil(t, unmarshaled[2].File.FileWithBytes)
+	assert.Equal(t, bytes, *unmarshaled[2].File.FileWithBytes)
+	require.NotNil(t, unmarshaled[2].Metadata)
+	assert.Equal(t, map[string]any{"size": float64(4)}, *unmarshaled[2].Metadata)
 }
 
 func TestMessageUnmarshalJSON(t *testing.T) {
@@ -237,63 +230,57 @@ func TestMessageUnmarshalJSON(t *testing.T) {
 		{
 			name: "message with text parts",
 			jsonData: `{
-				"kind": "message",
 				"messageId": "msg-123",
 				"role": "user",
 				"parts": [
-					{"kind": "text", "text": "Hello"},
-					{"kind": "text", "text": "World"}
+					{"text": "Hello"},
+					{"text": "World"}
 				]
 			}`,
 			validate: func(t *testing.T, msg Message) {
-				assert.Equal(t, "message", msg.Kind)
 				assert.Equal(t, "msg-123", msg.MessageID)
 				assert.Equal(t, "user", msg.Role)
 				require.Len(t, msg.Parts, 2)
 
-				textPart1, ok := msg.Parts[0].(TextPart)
-				require.True(t, ok, "First part should be TextPart")
-				assert.Equal(t, "Hello", textPart1.Text)
+				require.NotNil(t, msg.Parts[0].Text)
+				assert.Equal(t, "Hello", *msg.Parts[0].Text)
 
-				textPart2, ok := msg.Parts[1].(TextPart)
-				require.True(t, ok, "Second part should be TextPart")
-				assert.Equal(t, "World", textPart2.Text)
+				require.NotNil(t, msg.Parts[1].Text)
+				assert.Equal(t, "World", *msg.Parts[1].Text)
 			},
 		},
 		{
 			name: "message with mixed part types",
 			jsonData: `{
-				"kind": "message",
 				"messageId": "msg-456",
 				"role": "assistant",
 				"parts": [
-					{"kind": "text", "text": "Response"},
-					{"kind": "data", "data": {"result": "success"}},
-					{"kind": "file", "file": {"name": "test.txt"}}
+					{"text": "Response"},
+					{"data": {"data": {"result": "success"}}},
+					{"file": {"name": "test.txt", "mediaType": "text/plain"}}
 				]
 			}`,
 			validate: func(t *testing.T, msg Message) {
 				assert.Equal(t, "assistant", msg.Role)
 				require.Len(t, msg.Parts, 3)
 
-				_, ok := msg.Parts[0].(TextPart)
-				assert.True(t, ok, "First part should be TextPart")
+				require.NotNil(t, msg.Parts[0].Text)
+				assert.Equal(t, "Response", *msg.Parts[0].Text)
 
-				_, ok = msg.Parts[1].(DataPart)
-				assert.True(t, ok, "Second part should be DataPart")
+				require.NotNil(t, msg.Parts[1].Data)
+				assert.Equal(t, map[string]any{"result": "success"}, msg.Parts[1].Data.Data)
 
-				_, ok = msg.Parts[2].(FilePart)
-				assert.True(t, ok, "Third part should be FilePart")
+				require.NotNil(t, msg.Parts[2].File)
+				assert.Equal(t, "test.txt", msg.Parts[2].File.Name)
 			},
 		},
 		{
 			name: "message round-trip with typed parts",
 			jsonData: `{
-				"kind": "message",
 				"messageId": "msg-789",
 				"role": "user",
 				"parts": [
-					{"kind": "text", "text": "Test message", "metadata": {"key": "value"}}
+					{"text": "Test message", "metadata": {"key": "value"}}
 				]
 			}`,
 			validate: func(t *testing.T, msg Message) {
@@ -304,10 +291,10 @@ func TestMessageUnmarshalJSON(t *testing.T) {
 				err = json.Unmarshal(marshaled, &msg2)
 				require.NoError(t, err)
 
-				textPart, ok := msg2.Parts[0].(TextPart)
-				require.True(t, ok, "Part should remain TextPart after round-trip")
-				assert.Equal(t, "Test message", textPart.Text)
-				assert.Equal(t, map[string]any{"key": "value"}, textPart.Metadata)
+				require.NotNil(t, msg2.Parts[0].Text)
+				assert.Equal(t, "Test message", *msg2.Parts[0].Text)
+				require.NotNil(t, msg2.Parts[0].Metadata)
+				assert.Equal(t, map[string]any{"key": "value"}, *msg2.Parts[0].Metadata)
 			},
 		},
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -1,36 +1,5 @@
 package types
 
-// MessagePartKind represents the different types of message parts supported by A2A protocol.
-// Based on the A2A specification: https://google-a2a.github.io/A2A/latest/
-type MessagePartKind string
-
-// MessagePartKind enum values for the three official message part types
-const (
-	// MessagePartKindText represents a text segment within message parts
-	MessagePartKindText MessagePartKind = "text"
-
-	// MessagePartKindFile represents a file segment within message parts
-	MessagePartKindFile MessagePartKind = "file"
-
-	// MessagePartKindData represents a structured data segment within message parts
-	MessagePartKindData MessagePartKind = "data"
-)
-
-// String returns the string representation of the MessagePartKind
-func (k MessagePartKind) String() string {
-	return string(k)
-}
-
-// IsValid checks if the MessagePartKind is one of the supported values
-func (k MessagePartKind) IsValid() bool {
-	switch k {
-	case MessagePartKindText, MessagePartKindFile, MessagePartKindData:
-		return true
-	default:
-		return false
-	}
-}
-
 // Health status constants
 const (
 	HealthStatusHealthy   = "healthy"
@@ -118,22 +87,6 @@ type MessageSendParams struct {
 	Message       Message                   `json:"message"`
 	Metadata      map[string]any            `json:"metadata,omitempty"`
 }
-
-// Defines the lifecycle states of a Task.
-type TaskState string
-
-// TaskState enum values
-const (
-	TaskStateAuthRequired  TaskState = "auth-required"
-	TaskStateCanceled      TaskState = "canceled"
-	TaskStateCompleted     TaskState = "completed"
-	TaskStateFailed        TaskState = "failed"
-	TaskStateInputRequired TaskState = "input-required"
-	TaskStateRejected      TaskState = "rejected"
-	TaskStateSubmitted     TaskState = "submitted"
-	TaskStateUnknown       TaskState = "unknown"
-	TaskStateWorking       TaskState = "working"
-)
 
 // Defines parameters for querying a task, with an option to limit history length.
 type TaskQueryParams struct {

--- a/types/types.go
+++ b/types/types.go
@@ -56,3 +56,97 @@ const (
 const (
 	ToolInputRequired = "input_required"
 )
+
+// A discriminated union representing all possible JSON-RPC 2.0 responses
+// for the A2A specification methods.
+type JSONRPCResponse any
+
+// Represents a successful JSON-RPC 2.0 Response object.
+type JSONRPCSuccessResponse struct {
+	ID      any    `json:"id"`
+	JSONRPC string `json:"jsonrpc"`
+	Result  any    `json:"result"`
+}
+
+// An error indicating that the server received invalid JSON.
+type JSONParseError struct {
+	Code    int    `json:"code"`
+	Data    *any   `json:"data,omitempty"`
+	Message string `json:"message"`
+}
+
+// Represents a JSON-RPC 2.0 Error object, included in an error response.
+type JSONRPCError struct {
+	Code    int    `json:"code"`
+	Data    *any   `json:"data,omitempty"`
+	Message string `json:"message"`
+}
+
+// Represents a JSON-RPC 2.0 Error Response object.
+type JSONRPCErrorResponse struct {
+	Error   any    `json:"error"`
+	ID      any    `json:"id"`
+	JSONRPC string `json:"jsonrpc"`
+}
+
+// Defines the base structure for any JSON-RPC 2.0 request, response, or notification.
+type JSONRPCMessage struct {
+	ID      *any   `json:"id,omitempty"`
+	JSONRPC string `json:"jsonrpc"`
+}
+
+// Represents a JSON-RPC 2.0 Request object.
+type JSONRPCRequest struct {
+	ID      *any           `json:"id,omitempty"`
+	JSONRPC string         `json:"jsonrpc"`
+	Method  string         `json:"method"`
+	Params  map[string]any `json:"params,omitempty"`
+}
+
+// Defines configuration options for a `message/send` or `message/stream` request.
+type MessageSendConfiguration struct {
+	AcceptedOutputModes    []string                `json:"acceptedOutputModes,omitempty"`
+	Blocking               *bool                   `json:"blocking,omitempty"`
+	HistoryLength          *int                    `json:"historyLength,omitempty"`
+	PushNotificationConfig *PushNotificationConfig `json:"pushNotificationConfig,omitempty"`
+}
+
+// Defines the parameters for a request to send a message to an agent. This can be used
+// to create a new task, continue an existing one, or restart a task.
+type MessageSendParams struct {
+	Configuration *MessageSendConfiguration `json:"configuration,omitempty"`
+	Message       Message                   `json:"message"`
+	Metadata      map[string]any            `json:"metadata,omitempty"`
+}
+
+// Defines the lifecycle states of a Task.
+type TaskState string
+
+// TaskState enum values
+const (
+	TaskStateAuthRequired  TaskState = "auth-required"
+	TaskStateCanceled      TaskState = "canceled"
+	TaskStateCompleted     TaskState = "completed"
+	TaskStateFailed        TaskState = "failed"
+	TaskStateInputRequired TaskState = "input-required"
+	TaskStateRejected      TaskState = "rejected"
+	TaskStateSubmitted     TaskState = "submitted"
+	TaskStateUnknown       TaskState = "unknown"
+	TaskStateWorking       TaskState = "working"
+)
+
+// Defines parameters for querying a task, with an option to limit history length.
+type TaskQueryParams struct {
+	HistoryLength *int           `json:"historyLength,omitempty"`
+	ID            string         `json:"id"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+}
+
+// Parameters for listing tasks with optional filtering and pagination.
+type TaskListParams struct {
+	ContextID *string        `json:"contextId,omitempty"`
+	Limit     int            `json:"limit,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+	Offset    int            `json:"offset,omitempty"`
+	State     *TaskState     `json:"state,omitempty"`
+}

--- a/types/types.go
+++ b/types/types.go
@@ -150,3 +150,21 @@ type TaskListParams struct {
 	Offset    int            `json:"offset,omitempty"`
 	State     *TaskState     `json:"state,omitempty"`
 }
+
+// Parameters for task operations that require only a task ID.
+type TaskIdParams struct {
+	ID       string         `json:"id"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// TaskList represents a list of tasks with pagination info (alias for generated type)
+type TaskList = ListTasksResponse
+
+// GetTaskPushNotificationConfigParams is an alias for GetTaskPushNotificationConfigRequest
+type GetTaskPushNotificationConfigParams = GetTaskPushNotificationConfigRequest
+
+// ListTaskPushNotificationConfigParams is an alias for ListTaskPushNotificationConfigRequest
+type ListTaskPushNotificationConfigParams = ListTaskPushNotificationConfigRequest
+
+// DeleteTaskPushNotificationConfigParams is an alias for DeleteTaskPushNotificationConfigRequest
+type DeleteTaskPushNotificationConfigParams = DeleteTaskPushNotificationConfigRequest


### PR DESCRIPTION
## Overview

This PR completes the migration of the Agent Development Kit (ADK) to the A2A (Agent-to-Agent) Protocol Schema v0.3.0. The migration addresses breaking changes in the protocol specification, including the new Part type system, typed role constants, and state-based task management.

## Breaking Changes

### 1. Part Type System Migration

**Before (Interface-based discriminated union):**
```go
message := types.Message{
    Role: "user",
    Parts: []types.Part{
        types.TextPart{
            Kind: "text",
            Text: "Hello",
        },
    },
}

// Access via type assertion
if textPart, ok := part.(types.TextPart); ok {
    fmt.Println(textPart.Text)
}
```

**After (Struct with optional fields and helper functions):**
```go
message := types.Message{
    Role: types.RoleUser,
    Parts: []types.Part{
        types.CreateTextPart("Hello"),
    },
}

// Access via field check
if part.Text != nil {
    fmt.Println(*part.Text)
}
```

### 2. Role Type System

**Before (String literals):**
```go
Role: "user"
Role: "assistant"
```

**After (Typed constants):**
```go
Role: types.RoleUser        // "ROLE_USER"
Role: types.RoleAgent       // "ROLE_AGENT"
Role: types.RoleUnspecified // "ROLE_UNSPECIFIED"
```

**Note:** A2A protocol has NO `ROLE_SYSTEM` - system prompts are agent configuration, not messages.

### 3. Input-Required State Management

**Before (Checking non-existent `Kind` field):**
```go
if msg.Kind == "input_required" {  // ❌ Field doesn't exist!
    // handle input required
}
```

**After (State-based checking):**
```go
if task.Status.State == types.TaskStateInputRequired {
    // Task is paused waiting for user input
    // Check task.Status.Message for the prompt sent to user
}
```

### 4. Message Converter Role Mapping

Established proper bidirectional mapping between A2A protocol (typed roles) and OpenAI SDK (string roles):

**A2A → SDK:**
- `types.RoleUser` → `sdk.User`
- `types.RoleAgent` → `sdk.Assistant` (or `sdk.Tool` if `tool_call_id` present)
- `types.RoleUnspecified` → `sdk.User`

**SDK → A2A:**
- `"user"` → `types.RoleUser`
- `"assistant"`, `"tool"`, `"system"` → `types.RoleAgent`

## Files Changed

### Core SDK Files

- **`server/utils/message_converter.go`**: Updated role mapping between A2A and OpenAI SDK formats, removed legacy string literal support

### Example Files (30+ files updated)

**AI-Powered Examples:**
- `examples/ai-powered/client/main.go`
- `examples/ai-powered/server/main.go`
- `examples/ai-powered-streaming/client/main.go`
- `examples/ai-powered-streaming/server/main.go`

**Input-Required Examples:**
- `examples/input-required/non-streaming/client/main.go`
- `examples/input-required/non-streaming/server/main.go`
- `examples/input-required/streaming/client/main.go`
- `examples/input-required/streaming/server/main.go`

**Artifact Examples:**
- `examples/artifacts-autonomous-tool/server/main.go`
- `examples/artifacts-filesystem/server/main.go`
- `examples/artifacts-minio/server/main.go`
- `examples/artifacts-with-default-handlers/server/main.go`

**Other Examples:**
- `examples/callbacks/server/main.go`
- `examples/default-handlers/server/main.go`
- `examples/minimal/server/main.go`
- `examples/queue-storage/in-memory/server/main.go`
- `examples/queue-storage/redis/server/main.go`
- `examples/static-agent-card/server/main.go`
- `examples/streaming/client/main.go`
- `examples/streaming/server/main.go`
- `examples/tls-server/server/main.go`

**Configuration:**
- `.markdownlint-cli2.jsonc`: Updated line length from 80 to 140 characters

## Key Fixes

### 1. Part Construction
- Replaced manual struct construction with helper functions:
  - `types.CreateTextPart(text)`
  - `types.CreateDataPart(data, mimeType)`
  - `types.CreateFilePart(file)`

### 2. Part Access Patterns
- Changed from type assertions to field presence checks:
  - `if part.Text != nil { *part.Text }`
  - `if part.File != nil { part.File.Name }`
  - `if part.Data != nil { part.Data.MimeType }`

### 3. Role Usage
- Enforced typed role constants throughout all examples
- Maintained OpenAI SDK compatibility in internal converter

### 4. Input-Required Flow
- Fixed fundamental misunderstanding in input-required examples:
  - Input-required is a **task state**, not a message property
  - Context determined by examining `task.Status.Message`
  - Removed fragile text pattern matching

### 5. Streaming Event Processing
- Fixed event discrimination to use field presence:
  - Check `task.Status.Message != nil` instead of `task.Kind == "task"`
  - Check `statusUpdate.TaskID != ""` instead of `statusUpdate.Kind != "status-update"`

## Testing

All verification steps completed successfully:

✅ **Code Quality:**
```bash
task lint           # 0 issues found
task lint:examples  # 0 issues found
```

✅ **Tests:**
```bash
task test  # All tests passing
```

✅ **Examples:**
- All 30+ example applications build successfully
- Docker builds verified for all examples
- Integration tests passing

## Migration Guide

For users upgrading to A2A v0.3.0:

1. **Update Part construction:**
   ```go
   // Old
   types.TextPart{Kind: "text", Text: "message"}
   
   // New
   types.CreateTextPart("message")
   ```

2. **Update Role usage:**
   ```go
   // Old
   Role: "user"
   Role: "assistant"
   
   // New
   Role: types.RoleUser
   Role: types.RoleAgent
   ```

3. **Update Part access:**
   ```go
   // Old
   if textPart, ok := part.(types.TextPart); ok {
       text := textPart.Text
   }
   
   // New
   if part.Text != nil {
       text := *part.Text
   }
   ```

4. **Update input-required handling:**
   ```go
   // Old
   if msg.Kind == "input_required" { ... }
   
   // New
   if task.Status.State == types.TaskStateInputRequired {
       prompt := getMessageText(task.Status.Message)
   }
   ```

---

### TODOs

- [ ] Regression - ensure examples are still working as expected
- [ ] Docs - ensure documentation is up to date 