### PR TITLE
chore(deps): Bump Go to 1.26 and update tooling dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/devcontainers/go:2-1.25-bookworm
+FROM mcr.microsoft.com/devcontainers/go:2-1.26-bookworm
 
-ENV TASK_VERSION=v3.45.4 \
-    GOLANG_CI_LINT_VERSION=v2.5.0 \
-    GITHUB_CLI_VERSION=2.74.0 \
+ENV TASK_VERSION=v3.48.0 \
+    GOLANG_CI_LINT_VERSION=v2.11.4 \
+    GITHUB_CLI_VERSION=2.89.0 \
     NODE_VERSION=lts \
-    SEMANTIC_RELEASE_VERSION=v24.2.9
+    SEMANTIC_RELEASE_VERSION=v25.0.2
 
 RUN apt-get update && \
     # Determine architecture

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -5,23 +5,27 @@
     "install": {
       "claude-code": {
         "pkg-path": "claude-code",
-        "version": "^2.0.76"
+        "version": "^2.1.104"
       },
       "gh": {
         "pkg-path": "gh",
-        "version": "^2.83.2"
+        "version": "^2.89.0"
       },
       "go": {
         "pkg-path": "go",
-        "version": "^1.25.4"
+        "version": "^1.26.1"
+      },
+      "go-task": {
+        "pkg-path": "go-task",
+        "version": "3.48.0"
       },
       "golangci-lint": {
         "pkg-path": "golangci-lint",
-        "version": "^2.7.2"
+        "version": "^2.11.4"
       },
       "markdownlint-cli2": {
         "pkg-path": "markdownlint-cli2",
-        "version": "0.18.1"
+        "version": "0.21.0"
       },
       "mockgen": {
         "pkg-path": "mockgen",
@@ -41,27 +45,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/mhfj4qzf10fv2jv9njf0b4jpp7inx6k2-claude-code-2.0.76.drv",
+      "derivation": "/nix/store/a919rfiwqx8rmznldfd5li5ws5bm98v8-claude-code-2.1.104.drv",
       "description": "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "claude-code-2.0.76",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "claude-code-2.1.104",
       "pname": "claude-code",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:02:38.420390Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:05:18.226478Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.0.76",
+      "version": "2.1.104",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/x9y8cms1gm1sk9vjcqgf40yk9y13qa77-claude-code-2.0.76"
+        "out": "/nix/store/mzb7ph3wfmics5wx0bqnns0gga03g3p6-claude-code-2.1.104"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -70,27 +74,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/mrdvhrl2yfsd6f6cqsnrv9xcck81hxc9-claude-code-2.0.76.drv",
+      "derivation": "/nix/store/77qvv4bbisz2grapw4d2xjiiw095wvfb-claude-code-2.1.104.drv",
       "description": "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "claude-code-2.0.76",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "claude-code-2.1.104",
       "pname": "claude-code",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:18:00.849905Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:37:13.113750Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.0.76",
+      "version": "2.1.104",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/1g9prcgxkbi9aw76ym1ygwmv7bldifz4-claude-code-2.0.76"
+        "out": "/nix/store/s62mb6f2bragvq41xxk39hqcqlpbgmbv-claude-code-2.1.104"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -99,27 +103,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/h9lpg0hdb28z4byx51n5vycv5f4rq7xy-claude-code-2.0.76.drv",
+      "derivation": "/nix/store/bl3anq4kjbn214d2aabxsldrvlq3ffmk-claude-code-2.1.104.drv",
       "description": "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "claude-code-2.0.76",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "claude-code-2.1.104",
       "pname": "claude-code",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:34:53.660213Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:08:02.202352Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.0.76",
+      "version": "2.1.104",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/0vqxdvk72pimgpzqlp95dgla3idld3ks-claude-code-2.0.76"
+        "out": "/nix/store/72ai16sv9niclacl3lgks81s4czxh7vn-claude-code-2.1.104"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -128,27 +132,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/1wk6c1wjmc2nx6n3ii7sbscx4qpca955-claude-code-2.0.76.drv",
+      "derivation": "/nix/store/r0js6n9cq8v9rfjkjp6pjas6jjkm0aqq-claude-code-2.1.104.drv",
       "description": "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "claude-code-2.0.76",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "claude-code-2.1.104",
       "pname": "claude-code",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:50:18.427137Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:42:41.357604Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.0.76",
+      "version": "2.1.104",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/vmmvfrvjnhyip979rfbr3h21sickgh3a-claude-code-2.0.76"
+        "out": "/nix/store/ldng15znfpd2xa1q6zggw6bh8kk5nsld-claude-code-2.1.104"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -157,27 +161,27 @@
     {
       "attr_path": "gh",
       "broken": false,
-      "derivation": "/nix/store/pq71px0q7ffiw9py1yv06vsdg5vna28k-gh-2.83.2.drv",
+      "derivation": "/nix/store/l0b2d8r7qkarzii23xqjvp9hblppxr67-gh-2.89.0.drv",
       "description": "GitHub CLI tool",
       "install_id": "gh",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "gh-2.83.2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "gh-2.89.0",
       "pname": "gh",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:02:39.145636Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:05:19.049613Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.83.2",
+      "version": "2.89.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/v09g9zh0bwfjrfcq81k167jk8fnaql4x-gh-2.83.2"
+        "out": "/nix/store/ifqpbjcfx5snmahgny6lx40wxbh2yr7g-gh-2.89.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -186,27 +190,27 @@
     {
       "attr_path": "gh",
       "broken": false,
-      "derivation": "/nix/store/ixcdwldr265f6w3f1mz4vhrili4illgr-gh-2.83.2.drv",
+      "derivation": "/nix/store/3d4g19zfh814czzi3g73grh2hc39n2d6-gh-2.89.0.drv",
       "description": "GitHub CLI tool",
       "install_id": "gh",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "gh-2.83.2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "gh-2.89.0",
       "pname": "gh",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:18:01.996756Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:37:14.356653Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.83.2",
+      "version": "2.89.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/8a3gc9smfgmimvvsgjncij1p3hrkbycq-gh-2.83.2"
+        "out": "/nix/store/kx2h8n89f8c7a8js867836msdvsfif4j-gh-2.89.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -215,27 +219,27 @@
     {
       "attr_path": "gh",
       "broken": false,
-      "derivation": "/nix/store/390l3ygqwmn5xh7aq08nsyspz0821z9h-gh-2.83.2.drv",
+      "derivation": "/nix/store/fx8m0zrkl7gkdxv189a4khpm1dk5311j-gh-2.89.0.drv",
       "description": "GitHub CLI tool",
       "install_id": "gh",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "gh-2.83.2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "gh-2.89.0",
       "pname": "gh",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:34:54.413838Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:08:03.015893Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.83.2",
+      "version": "2.89.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/cc4glclba1gffbxddd8vyyh8k69c145w-gh-2.83.2"
+        "out": "/nix/store/20pxzdzqba82zcy2zwqcsdn9imjrhg24-gh-2.89.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -244,27 +248,27 @@
     {
       "attr_path": "gh",
       "broken": false,
-      "derivation": "/nix/store/agqv8nm0xfbydqcbdxgnx9zg5nkw66hz-gh-2.83.2.drv",
+      "derivation": "/nix/store/14zbgfjimkaxsz8ipb4dz46ip1jmhqwh-gh-2.89.0.drv",
       "description": "GitHub CLI tool",
       "install_id": "gh",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "gh-2.83.2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "gh-2.89.0",
       "pname": "gh",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:50:19.746078Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:42:42.816491Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.83.2",
+      "version": "2.89.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/1ga8sgks3i0iwdl33aazgql8gfsxnqjc-gh-2.83.2"
+        "out": "/nix/store/1131yfwz32j7ad860qy9ksvbiid2hv0k-gh-2.89.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -273,27 +277,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/zaq4xq9hw1b7a4azgghhh07cpc1ynmin-go-1.25.4.drv",
+      "derivation": "/nix/store/jj5lr2n85rl99d40dcgvv8kh4p37i47d-go-1.26.1.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "go-1.25.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "go-1.26.1",
       "pname": "go",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:02:39.290078Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:05:19.213036Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.25.4",
+      "version": "1.26.1",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/52f5kjcmgmvgrz3rij676b3rjmgg5l5g-go-1.25.4"
+        "out": "/nix/store/kh43nhaz1qcpwws2xq805lrmwpmn9i3k-go-1.26.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -302,27 +306,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/hf3knc631mw1pq84qv1hk5jvs467k1v4-go-1.25.4.drv",
+      "derivation": "/nix/store/bgblqd7l0v7x7s504csalw9b5vwf4czc-go-1.26.1.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "go-1.25.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "go-1.26.1",
       "pname": "go",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:18:02.886715Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:37:15.076978Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.25.4",
+      "version": "1.26.1",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/2ajrlmz1qdpm9k9ankhnp3973wxg1gqs-go-1.25.4"
+        "out": "/nix/store/rz1pqbm5z3zfby250i0djfmfzzj7khg9-go-1.26.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -331,27 +335,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/4bmjpvr4w7cw86fqwi1fcm3dq8z2d5pp-go-1.25.4.drv",
+      "derivation": "/nix/store/pcwra0rv1n0pq3r6sjlc6sx6a0bv499x-go-1.26.1.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "go-1.25.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "go-1.26.1",
       "pname": "go",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:34:54.593400Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:08:03.210482Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.25.4",
+      "version": "1.26.1",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/1rqpvp45rl4sr1l0czrlbmv8jqj9sa7r-go-1.25.4"
+        "out": "/nix/store/yv6jj27racylbfjw6a1cdr91ndxbgyf6-go-1.26.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -360,27 +364,144 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/zgcfmmah54wp3d2ln1wh9f8ykh4pp8xc-go-1.25.4.drv",
+      "derivation": "/nix/store/f7rh1lw0shd5471j9y6wpvc2j43czglz-go-1.26.1.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "go-1.25.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "go-1.26.1",
       "pname": "go",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:50:20.429117Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:42:43.606124Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.25.4",
+      "version": "1.26.1",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ckcq2mj8zk0drhaaacy6mp9d924hnr4m-go-1.26.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "go-task",
+      "broken": false,
+      "derivation": "/nix/store/d75iigh6jr411wnb6gk1dqwy6ybv4a07-go-task-3.48.0.drv",
+      "description": "Task runner / simpler Make alternative written in Go",
+      "install_id": "go-task",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "go-task-3.48.0",
+      "pname": "go-task",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:05:19.234061Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "3.48.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/0a3dyfq09dnkw28ap2i450wjimvdmv6s-go-1.25.4"
+        "out": "/nix/store/sab4xhgi6cs6rnxsx33dxqg2zcir52rm-go-task-3.48.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "go-task",
+      "broken": false,
+      "derivation": "/nix/store/4yafn203k3iq871ahgmlk39lyb976lvr-go-task-3.48.0.drv",
+      "description": "Task runner / simpler Make alternative written in Go",
+      "install_id": "go-task",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "go-task-3.48.0",
+      "pname": "go-task",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:37:15.106990Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "3.48.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/cidnjfhcp1qyxjih6qaa61hfyxy5k5ap-go-task-3.48.0"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "go-task",
+      "broken": false,
+      "derivation": "/nix/store/np5hkd93wdzh9s9ynkdk3mds3pg1bifz-go-task-3.48.0.drv",
+      "description": "Task runner / simpler Make alternative written in Go",
+      "install_id": "go-task",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "go-task-3.48.0",
+      "pname": "go-task",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:08:03.231502Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "3.48.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/nxbwqrg7jx4l16q1c37kr510cv0cz1cw-go-task-3.48.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "go-task",
+      "broken": false,
+      "derivation": "/nix/store/f2xbx67ryzzcxd851bwnc5jcgxb4a032-go-task-3.48.0.drv",
+      "description": "Task runner / simpler Make alternative written in Go",
+      "install_id": "go-task",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "go-task-3.48.0",
+      "pname": "go-task",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:42:43.638049Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "3.48.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/qxs1p264gzz3nficzss2nsp7fs5cdi31-go-task-3.48.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -389,27 +510,27 @@
     {
       "attr_path": "golangci-lint",
       "broken": false,
-      "derivation": "/nix/store/h6hmls6bhy0an6dc8jnnywdp56hyymcw-golangci-lint-2.7.2.drv",
+      "derivation": "/nix/store/yhb07d2wsdwxsqvmvhbqf20pjckshv4v-golangci-lint-2.11.4.drv",
       "description": "Fast linters Runner for Go",
       "install_id": "golangci-lint",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "golangci-lint-2.7.2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "golangci-lint-2.11.4",
       "pname": "golangci-lint",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:02:39.350318Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:05:19.278640Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.7.2",
+      "version": "2.11.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/q3a6xszcxa3rcaq2xa5hli5ynsw9p2xj-golangci-lint-2.7.2"
+        "out": "/nix/store/zjhq23zqjjlyclylkwvny6s7qzcq56n4-golangci-lint-2.11.4"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -418,27 +539,27 @@
     {
       "attr_path": "golangci-lint",
       "broken": false,
-      "derivation": "/nix/store/j62j0p76bsd3qxblg777ck3vhffpwijk-golangci-lint-2.7.2.drv",
+      "derivation": "/nix/store/vknh40qizw72lnwiv90cyab3m8da4dvb-golangci-lint-2.11.4.drv",
       "description": "Fast linters Runner for Go",
       "install_id": "golangci-lint",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "golangci-lint-2.7.2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "golangci-lint-2.11.4",
       "pname": "golangci-lint",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:18:02.972469Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:37:15.172969Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.7.2",
+      "version": "2.11.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/26ckbfx1m91f1ix7x1v8zckvnccvf03g-golangci-lint-2.7.2"
+        "out": "/nix/store/6rnv5q31z65m0cx0gsclybizgly224r8-golangci-lint-2.11.4"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -447,27 +568,27 @@
     {
       "attr_path": "golangci-lint",
       "broken": false,
-      "derivation": "/nix/store/w3ilgwgv52rh1q2xiqg0j68ask5pv4yy-golangci-lint-2.7.2.drv",
+      "derivation": "/nix/store/qclqnf46p70n30fya545xnkjxjsjf7bx-golangci-lint-2.11.4.drv",
       "description": "Fast linters Runner for Go",
       "install_id": "golangci-lint",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "golangci-lint-2.7.2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "golangci-lint-2.11.4",
       "pname": "golangci-lint",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:34:54.642695Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:08:03.272198Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.7.2",
+      "version": "2.11.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/4ngz15pamb1mvbgk8vqsdc7am0sm3nfl-golangci-lint-2.7.2"
+        "out": "/nix/store/laj0sxwhanwj9nk8hnsqzsj1b141z2bm-golangci-lint-2.11.4"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -476,27 +597,27 @@
     {
       "attr_path": "golangci-lint",
       "broken": false,
-      "derivation": "/nix/store/5dicahp4k4657qqpdy6rg9kx9pnxdw7j-golangci-lint-2.7.2.drv",
+      "derivation": "/nix/store/6hc83ga5aylvdpjy3fbajcqr2k75d52v-golangci-lint-2.11.4.drv",
       "description": "Fast linters Runner for Go",
       "install_id": "golangci-lint",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "golangci-lint-2.7.2",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "golangci-lint-2.11.4",
       "pname": "golangci-lint",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:50:20.519278Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:42:43.709276Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.7.2",
+      "version": "2.11.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/20pjxaqyh10abjhc0by39q7rv3frmx1j-golangci-lint-2.7.2"
+        "out": "/nix/store/j4w0z1lgrs4fdds7npk2bnby5ks612cf-golangci-lint-2.11.4"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -505,27 +626,27 @@
     {
       "attr_path": "markdownlint-cli2",
       "broken": false,
-      "derivation": "/nix/store/3j1x1ick532i0kk9lr30pkc08y3caldr-markdownlint-cli2-0.18.1.drv",
+      "derivation": "/nix/store/wssa9sq3znfajjvh439wjyy3mwhf5bmc-markdownlint-cli2-0.21.0.drv",
       "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
       "install_id": "markdownlint-cli2",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "markdownlint-cli2-0.18.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "markdownlint-cli2-0.21.0",
       "pname": "markdownlint-cli2",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:02:57.773225Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:05:39.764096Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.18.1",
+      "version": "0.21.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7siafnyzrfq6ki0qwa79h0c7g0h9xkkx-markdownlint-cli2-0.18.1"
+        "out": "/nix/store/snfqccf95i05iiz0kffaij4bz08kzb0c-markdownlint-cli2-0.21.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -534,27 +655,27 @@
     {
       "attr_path": "markdownlint-cli2",
       "broken": false,
-      "derivation": "/nix/store/srw5jiybh2pi55n6ck747q2vscvqhbdq-markdownlint-cli2-0.18.1.drv",
+      "derivation": "/nix/store/b08vi4anjvsl97mxhyhg5giay0vikrqp-markdownlint-cli2-0.21.0.drv",
       "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
       "install_id": "markdownlint-cli2",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "markdownlint-cli2-0.18.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "markdownlint-cli2-0.21.0",
       "pname": "markdownlint-cli2",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:18:33.694619Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:37:46.617271Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.18.1",
+      "version": "0.21.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yg2gmljd4bzd7qsbxkxp5gmz9lli6jg9-markdownlint-cli2-0.18.1"
+        "out": "/nix/store/vrpidr9nvanw74gr29lsvfggv2x74bgs-markdownlint-cli2-0.21.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -563,27 +684,27 @@
     {
       "attr_path": "markdownlint-cli2",
       "broken": false,
-      "derivation": "/nix/store/xmbxl0ciyl3cj3lzin5hlh5c4dpjz5i4-markdownlint-cli2-0.18.1.drv",
+      "derivation": "/nix/store/ycppl8zyv5mbv5yisznhfci9wfli1hn9-markdownlint-cli2-0.21.0.drv",
       "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
       "install_id": "markdownlint-cli2",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "markdownlint-cli2-0.18.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "markdownlint-cli2-0.21.0",
       "pname": "markdownlint-cli2",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:35:15.212338Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:08:23.616772Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.18.1",
+      "version": "0.21.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/q7h437plnm4phq9v4fj79flkrfwii42i-markdownlint-cli2-0.18.1"
+        "out": "/nix/store/75sdvy60h4h95bb0y03iwbz3f76b54wz-markdownlint-cli2-0.21.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -592,27 +713,27 @@
     {
       "attr_path": "markdownlint-cli2",
       "broken": false,
-      "derivation": "/nix/store/l7xr8a71zy00lrqc95kjnf6cil9knf10-markdownlint-cli2-0.18.1.drv",
+      "derivation": "/nix/store/2jdj2vcx5s6q43p8bc4j7piphlv46m63-markdownlint-cli2-0.21.0.drv",
       "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
       "install_id": "markdownlint-cli2",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "name": "markdownlint-cli2-0.18.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "name": "markdownlint-cli2-0.21.0",
       "pname": "markdownlint-cli2",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:50:53.342788Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:43:16.930030Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.18.1",
+      "version": "0.21.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/jyfhkhv3ij5lnx1sbjhfcizcz76lbbmd-markdownlint-cli2-0.18.1"
+        "out": "/nix/store/d00905i0s4qiqk8k94rik7rbjinw03kd-markdownlint-cli2-0.21.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -621,17 +742,17 @@
     {
       "attr_path": "mockgen",
       "broken": false,
-      "derivation": "/nix/store/rccqpsh6ifib5zm2v83nnsy73bhawcz6-mockgen-0.6.0.drv",
+      "derivation": "/nix/store/4nsg93baawhsi3720pjzrwgf8jhsldyl-mockgen-0.6.0.drv",
       "description": "Mocking framework for the Go programming language",
       "install_id": "mockgen",
       "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
       "name": "mockgen-0.6.0",
       "pname": "mockgen",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:02:58.395620Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:05:40.484238Z",
       "stabilities": [
         "unstable"
       ],
@@ -641,7 +762,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/3gnz0jdb78w2m0ps8i27hay62wbb3dsc-mockgen-0.6.0"
+        "out": "/nix/store/2d6x7lgpnmwzhl0m302ssgz0pp2bw35i-mockgen-0.6.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -650,17 +771,17 @@
     {
       "attr_path": "mockgen",
       "broken": false,
-      "derivation": "/nix/store/3zba4x8gvpbz2mza2lnk8dlhyc2k1b8q-mockgen-0.6.0.drv",
+      "derivation": "/nix/store/239avigkvfc3d53frb4whmyncmkvlpwj-mockgen-0.6.0.drv",
       "description": "Mocking framework for the Go programming language",
       "install_id": "mockgen",
       "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
       "name": "mockgen-0.6.0",
       "pname": "mockgen",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:18:34.937443Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:37:47.948034Z",
       "stabilities": [
         "unstable"
       ],
@@ -670,7 +791,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/2lbaspgkv59y2ah42r25nqp6q9kbldsc-mockgen-0.6.0"
+        "out": "/nix/store/n8wqvsq6zd6ag3pcyjd6mfiaqrc3cyk0-mockgen-0.6.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -679,17 +800,17 @@
     {
       "attr_path": "mockgen",
       "broken": false,
-      "derivation": "/nix/store/4d3gxc4582xpgvvx4ywnqrniq18wxcs9-mockgen-0.6.0.drv",
+      "derivation": "/nix/store/549859fagp5bip6klbpm3wr8h6i7j7n8-mockgen-0.6.0.drv",
       "description": "Mocking framework for the Go programming language",
       "install_id": "mockgen",
       "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
       "name": "mockgen-0.6.0",
       "pname": "mockgen",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:35:15.888971Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:08:24.328421Z",
       "stabilities": [
         "unstable"
       ],
@@ -699,7 +820,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/q56y5f2ydksa1b9r7692avn8r3wfmhlg-mockgen-0.6.0"
+        "out": "/nix/store/ivvixm23nb2wsd8avz50j7bx9zgplcmf-mockgen-0.6.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -708,17 +829,17 @@
     {
       "attr_path": "mockgen",
       "broken": false,
-      "derivation": "/nix/store/radxf2bs4ay5g3v1ms3silb5l3hdsnbx-mockgen-0.6.0.drv",
+      "derivation": "/nix/store/kjlm056r0b3f6kqlg4462f6vjbrjmqq4-mockgen-0.6.0.drv",
       "description": "Mocking framework for the Go programming language",
       "install_id": "mockgen",
       "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
       "name": "mockgen-0.6.0",
       "pname": "mockgen",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:50:54.779267Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:43:18.497065Z",
       "stabilities": [
         "unstable"
       ],
@@ -728,7 +849,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/hm9i9iv2brr3gw5m4lwxy8cx2lm57ncw-mockgen-0.6.0"
+        "out": "/nix/store/x3jxjbbx178pfkwxs78hjyv1ckdlvkmv-mockgen-0.6.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -737,17 +858,17 @@
     {
       "attr_path": "prettier",
       "broken": false,
-      "derivation": "/nix/store/4sy59js8jkvs588c8xq8rr68jf546j9a-prettier-3.6.2.drv",
+      "derivation": "/nix/store/5km4caqv72g6g7svncxfhxw1jgy79afp-prettier-3.6.2.drv",
       "description": "Code formatter",
       "install_id": "prettier",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
       "name": "prettier-3.6.2",
       "pname": "prettier",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:03:15.359224Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:05:57.330476Z",
       "stabilities": [
         "unstable"
       ],
@@ -757,7 +878,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/dfcvpnr7kwwsp979lhnd7wwnkgvpwpdc-prettier-3.6.2"
+        "out": "/nix/store/r48azz4l39w96zn152ybpcqxpkqpziz8-prettier-3.6.2"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -766,17 +887,17 @@
     {
       "attr_path": "prettier",
       "broken": false,
-      "derivation": "/nix/store/2qq0d5scnjg56x1z4isjp85m5zzb46w0-prettier-3.6.2.drv",
+      "derivation": "/nix/store/8132yiq38c0f7nn9fq41dxxjwq9y6ndr-prettier-3.6.2.drv",
       "description": "Code formatter",
       "install_id": "prettier",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
       "name": "prettier-3.6.2",
       "pname": "prettier",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:19:01.211913Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T06:38:11.503535Z",
       "stabilities": [
         "unstable"
       ],
@@ -786,7 +907,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/6jq20bylhhsgvfg8cpla0n1sfipn5fjr-prettier-3.6.2"
+        "out": "/nix/store/7vz0hyz8ysq4759y6mn931rx1zvn56hc-prettier-3.6.2"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -795,17 +916,17 @@
     {
       "attr_path": "prettier",
       "broken": false,
-      "derivation": "/nix/store/9r6b0kaqwwnji669mw516k8cfgdqmgm7-prettier-3.6.2.drv",
+      "derivation": "/nix/store/hr1i3pp50i5lh5fgcj22nl5c1zszcsh1-prettier-3.6.2.drv",
       "description": "Code formatter",
       "install_id": "prettier",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
       "name": "prettier-3.6.2",
       "pname": "prettier",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:35:34.089353Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:08:40.973835Z",
       "stabilities": [
         "unstable"
       ],
@@ -815,7 +936,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/gx0ky8rlym7wpqil80l7vxprr4y8vr2g-prettier-3.6.2"
+        "out": "/nix/store/ynj49sr067m60y1v7vs31k2iqc7n894a-prettier-3.6.2"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -824,17 +945,17 @@
     {
       "attr_path": "prettier",
       "broken": false,
-      "derivation": "/nix/store/hvp643i8m9jn4h8ygnw36h9vakabsazh-prettier-3.6.2.drv",
+      "derivation": "/nix/store/5gkb3dhcb0w2k4cpg4k0kaikikwyvr0n-prettier-3.6.2.drv",
       "description": "Code formatter",
       "install_id": "prettier",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
       "name": "prettier-3.6.2",
       "pname": "prettier",
-      "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
-      "rev_count": 917670,
-      "rev_date": "2025-12-28T06:08:05Z",
-      "scrape_date": "2025-12-29T03:51:20.636419Z",
+      "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+      "rev_count": 980183,
+      "rev_date": "2026-04-14T12:31:25Z",
+      "scrape_date": "2026-04-16T07:43:42.526590Z",
       "stabilities": [
         "unstable"
       ],
@@ -844,7 +965,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/6fcbrdsms2icrx5n840sslqd6nl7zfb7-prettier-3.6.2"
+        "out": "/nix/store/afhc5ydqajy6c848ylslxgxfqqi4c7mf-prettier-3.6.2"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -2,19 +2,21 @@ version = 1
 
 [install]
 go.pkg-path = "go"
-go.version = "^1.25.4"
+go.version = "^1.26.1"
 golangci-lint.pkg-path = "golangci-lint"
-golangci-lint.version = "^2.7.2"
+golangci-lint.version = "^2.11.4"
 prettier.pkg-path = "prettier"
 prettier.version = "3.6.2"
 claude-code.pkg-path = "claude-code"
-claude-code.version = "^2.0.76"
+claude-code.version = "^2.1.104"
 gh.pkg-path = "gh"
-gh.version = "^2.83.2"
+gh.version = "^2.89.0"
 markdownlint-cli2.pkg-path = "markdownlint-cli2"
-markdownlint-cli2.version = "0.18.1"
+markdownlint-cli2.version = "0.21.0"
 mockgen.pkg-path = "mockgen"
 mockgen.version = "0.6.0"
+go-task.pkg-path = "go-task"
+go-task.version = "3.48.0"
 
 [hook]
 on-activate = """

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6.1.0
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v2.7.2
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v2.11.4
 
       - name: Install Mockgen
         run: go install go.uber.org/mock/mockgen@v0.6.0
@@ -36,7 +36,7 @@ jobs:
         run: go install github.com/inference-gateway/tools/cmd/generator@v0.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.1.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,26 +32,26 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@v6.1.0
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v2.6.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v2.11.4
 
       - name: Install task
         run: |
-          curl -s https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin v3.45.4
+          curl -s https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin v3.48.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.1.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
     steps:
-      - uses: actions/create-github-app-token@v2.0.6
+      - uses: actions/create-github-app-token@v3.1.1
         id: app-token
         with:
           app-id: ${{ secrets.BOT_GH_APP_ID }}
@@ -40,7 +40,7 @@ jobs:
           git config --global commit.signoff true
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -48,13 +48,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: 'lts/*'
 
       - name: Install semantic release and plugins
         run: |
-          npm install -g semantic-release@v24.2.9 \
+          npm install -g semantic-release@v25.0.2 \
             conventional-changelog-cli \
             conventional-changelog-conventionalcommits \
             @semantic-release/changelog \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ We welcome contributions to the Application Development Kit for A2A-compatible A
 
 Before contributing, ensure you have the following installed:
 
-- **Go 1.25 or later**
+- **Go 1.26 or later**
 - **[Task](https://taskfile.dev/)** for build automation
 - **[golangci-lint](https://golangci-lint.run/)** for linting
 - **Git** for version control
@@ -120,7 +120,7 @@ For a containerized development environment with all tools pre-installed:
    task test
    ```
 
-The dev container includes all required tools: Go 1.25, Task, golangci-lint, GitHub CLI, Node.js, prettier, and more.
+The dev container includes all required tools: Go 1.26, Task, golangci-lint, GitHub CLI, Node.js, prettier, and more.
 
 #### Option 3: Manual Setup
 

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ This ADK is part of the broader Inference Gateway ecosystem:
 
 ## 📋 Requirements
 
-- **Go**: 1.25 or later
+- **Go**: 1.26 or later
 - **Dependencies**: See [go.mod](./go.mod) for full dependency list
 
 ## 🐳 Docker Support
@@ -561,7 +561,7 @@ This ADK is part of the broader Inference Gateway ecosystem:
 Build and run your A2A agent application in a container. Here's an example Dockerfile for an application using the ADK:
 
 ```dockerfile
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Build arguments for agent metadata
 ARG AGENT_NAME="My A2A Agent"

--- a/examples/Dockerfile.client
+++ b/examples/Dockerfile.client
@@ -2,7 +2,7 @@ ARG LD_FLAGS=""
 ARG EXAMPLE_PATH=""
 ARG COMPONENT="client"
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ARG LD_FLAGS
 ARG EXAMPLE_PATH

--- a/examples/Dockerfile.server
+++ b/examples/Dockerfile.server
@@ -4,7 +4,7 @@ ARG AGENT_VERSION=""
 ARG EXAMPLE_PATH=""
 ARG COMPONENT="server"
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ARG AGENT_NAME
 ARG AGENT_DESCRIPTION

--- a/examples/ai-powered-streaming/README.md
+++ b/examples/ai-powered-streaming/README.md
@@ -78,7 +78,7 @@ server.NewA2AServerBuilder(cfg.A2A, logger).
 
 - **LLM Provider**: This example requires an AI provider (OpenAI, Anthropic, etc.)
 - **API Key**: Valid API key for your chosen provider
-- **Go 1.25+**: For building and running the example
+- **Go 1.26+**: For building and running the example
 - **Streaming Enabled**: Server must have streaming capabilities enabled
 
 ## Configuration

--- a/examples/ai-powered-streaming/client/go.mod
+++ b/examples/ai-powered-streaming/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/ai-powered-streaming/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/ai-powered-streaming/server/go.mod
+++ b/examples/ai-powered-streaming/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/ai-powered-streaming/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/ai-powered/client/go.mod
+++ b/examples/ai-powered/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/ai-powered/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/ai-powered/server/go.mod
+++ b/examples/ai-powered/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/ai-powered/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/artifacts-autonomous-tool/README.md
+++ b/examples/artifacts-autonomous-tool/README.md
@@ -139,7 +139,7 @@ This will:
 
 #### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - An LLM API key (OpenAI, Anthropic, etc.)
 - Access to an Inference Gateway or direct LLM endpoint
 

--- a/examples/artifacts-autonomous-tool/client/go.mod
+++ b/examples/artifacts-autonomous-tool/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/artifacts-autonomous-tool/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/artifacts-autonomous-tool/server/go.mod
+++ b/examples/artifacts-autonomous-tool/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/artifacts-autonomous-tool/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/artifacts-filesystem/client/go.mod
+++ b/examples/artifacts-filesystem/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/artifacts-filesystem/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/artifacts-filesystem/server/go.mod
+++ b/examples/artifacts-filesystem/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/artifacts-filesystem/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/artifacts-minio/client/go.mod
+++ b/examples/artifacts-minio/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/artifacts-minio/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/artifacts-minio/server/go.mod
+++ b/examples/artifacts-minio/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/artifacts-minio/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/artifacts-with-default-handlers/README.md
+++ b/examples/artifacts-with-default-handlers/README.md
@@ -132,7 +132,7 @@ The default handlers automatically:
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.26 or later
 - Docker and Docker Compose (optional)
 
 ### Option 1: Using Docker Compose (Recommended)

--- a/examples/artifacts-with-default-handlers/client/go.mod
+++ b/examples/artifacts-with-default-handlers/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/artifacts-with-default-handlers/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/artifacts-with-default-handlers/server/go.mod
+++ b/examples/artifacts-with-default-handlers/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/artifacts-with-default-handlers/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/default-handlers/README.md
+++ b/examples/default-handlers/README.md
@@ -40,7 +40,7 @@ This approach provides:
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.26 or later
 - Docker and Docker Compose (optional)
 
 ### Option 1: Using Docker Compose (Recommended)

--- a/examples/default-handlers/client/go.mod
+++ b/examples/default-handlers/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/default-handlers/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/default-handlers/server/go.mod
+++ b/examples/default-handlers/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/default-handlers/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/input-required/non-streaming/client/go.mod
+++ b/examples/input-required/non-streaming/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/input-required/non-streaming/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../..
 

--- a/examples/input-required/non-streaming/server/go.mod
+++ b/examples/input-required/non-streaming/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/input-required/non-streaming/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../..
 

--- a/examples/input-required/streaming/client/go.mod
+++ b/examples/input-required/streaming/client/go.mod
@@ -1,6 +1,6 @@
 module input-required-streaming-client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../../
 

--- a/examples/input-required/streaming/server/go.mod
+++ b/examples/input-required/streaming/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/input-required/streaming/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../../
 

--- a/examples/minimal/client/go.mod
+++ b/examples/minimal/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/minimal/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/minimal/server/go.mod
+++ b/examples/minimal/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/minimal/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/queue-storage/in-memory/client/go.mod
+++ b/examples/queue-storage/in-memory/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/queue-storage/in-memory/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../../
 

--- a/examples/queue-storage/in-memory/server/go.mod
+++ b/examples/queue-storage/in-memory/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/queue-storage/in-memory/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../../
 

--- a/examples/queue-storage/redis/client/go.mod
+++ b/examples/queue-storage/redis/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/queue-storage/redis/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../../
 

--- a/examples/queue-storage/redis/server/go.mod
+++ b/examples/queue-storage/redis/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/queue-storage/redis/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../../
 

--- a/examples/streaming/client/go.mod
+++ b/examples/streaming/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/streaming/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/streaming/server/go.mod
+++ b/examples/streaming/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/streaming/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/tls-server/client/go.mod
+++ b/examples/tls-server/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/tls-example/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../
 

--- a/examples/tls-server/server/go.mod
+++ b/examples/tls-server/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/tls-example/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../../
 

--- a/examples/usage-metadata/client/go.mod
+++ b/examples/usage-metadata/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/usage-metadata/client
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/examples/usage-metadata/server/go.mod
+++ b/examples/usage-metadata/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk/examples/usage-metadata/server
 
-go 1.25.4
+go 1.26.1
 
 replace github.com/inference-gateway/adk => ../../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/inference-gateway/adk
 
-go 1.25.4
+go 1.26.1
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.25.4 to 1.26.1 across all modules (root + all examples)
- Bump CI tooling: golangci-lint v2.11.4, GitHub CLI v2.89.0, semantic-release v25.0.2, Task v3.48.0
- Update CI actions: checkout v6.0.2, setup-go v6.4.0, setup-node v6.3.0
- Update devcontainer and flox environment to match new versions
- Update docs (README, CONTRIBUTING) to reference Go 1.26
