### PR TITLE
fix: Include error details in streaming failed events and task status

### DIFF
--- a/server/agent_streamable.go
+++ b/server/agent_streamable.go
@@ -213,10 +213,22 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 					if streamErr != nil {
 						a.logger.Error("streaming failed", zap.Error(streamErr))
 
+						errorText := streamErr.Error()
+
+						errorMessage := types.NewStreamingStatusMessage(
+							fmt.Sprintf("streaming-error-%d", iteration),
+							string(types.TaskStateFailed),
+							map[string]any{"error": errorText},
+						)
+						errorMessage.Parts = append(errorMessage.Parts, types.NewTextPart(errorText))
+						errorMessage.TaskID = taskID
+						errorMessage.ContextID = contextID
+
 						failedStatusEvent := cloudevents.NewEvent()
 						failedStatusEvent.SetType(types.EventTaskStatusChanged)
 						if err := failedStatusEvent.SetData(cloudevents.ApplicationJSON, types.TaskStatus{
-							State: types.TaskStateFailed,
+							State:   types.TaskStateFailed,
+							Message: errorMessage,
 						}); err != nil {
 							a.logger.Error("failed to set failed status event data", zap.Error(err))
 							return
@@ -226,13 +238,6 @@ func (a *OpenAICompatibleAgentImpl) RunWithStream(ctx context.Context, messages 
 						default:
 						}
 
-						errorMessage := types.NewStreamingStatusMessage(
-							fmt.Sprintf("streaming-error-%d", iteration),
-							string(types.TaskStateFailed),
-							nil,
-						)
-						errorMessage.TaskID = taskID
-						errorMessage.ContextID = contextID
 						select {
 						case outputChan <- types.NewMessageEvent(types.EventStreamFailed, errorMessage.MessageID, errorMessage):
 						default:

--- a/server/agent_streamable_test.go
+++ b/server/agent_streamable_test.go
@@ -1425,9 +1425,48 @@ func TestRunWithStream_StreamFailedEventEmitted(t *testing.T) {
 	require.NoError(t, err)
 
 	eventTypes := make(map[string]int)
+	var streamFailedMsg *types.Message
+	var failedTaskStatus *types.TaskStatus
 	for event := range eventChan {
 		eventTypes[event.Type()]++
+		switch event.Type() {
+		case types.EventStreamFailed:
+			var msg types.Message
+			require.NoError(t, event.DataAs(&msg))
+			streamFailedMsg = &msg
+		case types.EventTaskStatusChanged:
+			var status types.TaskStatus
+			require.NoError(t, event.DataAs(&status))
+			if status.State == types.TaskStateFailed {
+				failedTaskStatus = &status
+			}
+		}
 	}
 
 	assert.Greater(t, eventTypes[types.EventStreamFailed], 0, "Should emit stream.failed event on error")
+
+	require.NotNil(t, streamFailedMsg, "stream.failed event must carry a message payload")
+	var streamFailedText, streamFailedData string
+	for _, p := range streamFailedMsg.Parts {
+		if p.Text != nil {
+			streamFailedText = *p.Text
+		}
+		if p.Data != nil {
+			if e, ok := p.Data.Data["error"].(string); ok {
+				streamFailedData = e
+			}
+		}
+	}
+	assert.Contains(t, streamFailedText, "streaming connection error", "stream.failed message must carry the underlying error as a TextPart")
+	assert.Contains(t, streamFailedData, "streaming connection error", "stream.failed message must carry the underlying error in the DataPart \"error\" key")
+
+	require.NotNil(t, failedTaskStatus, "task.status.changed event with TaskStateFailed must be emitted")
+	require.NotNil(t, failedTaskStatus.Message, "failed TaskStatus must include a Message describing the error")
+	var failedStatusText string
+	for _, p := range failedTaskStatus.Message.Parts {
+		if p.Text != nil {
+			failedStatusText = *p.Text
+		}
+	}
+	assert.Contains(t, failedStatusText, "streaming connection error", "TaskStatus.Message must carry the underlying error as a TextPart")
 }


### PR DESCRIPTION
Moved error message creation to include error text as TextPart and DataPart in both stream.failed event and task.status.changed event when streaming fails. Updated tests to verify the error details are propagated correctly.