### PR TITLE
feat(server): Wire EnableUsageMetadata config flag to default task handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ for evt := range events {
 The JSON-RPC counterpart to the public `.well-known/agent-card.json`
 endpoint. The response is the same `AgentCard` object, but the call passes
 through the JSON-RPC route and is therefore subject to the server's
-authentication middleware — useful when the extended card should only be
+authentication middleware - useful when the extended card should only be
 visible to authenticated callers.
 
 ```go

--- a/examples/protocol-methods/client/main.go
+++ b/examples/protocol-methods/client/main.go
@@ -154,7 +154,7 @@ func setupPushNotificationConfig(ctx context.Context, a2a client.A2AClient, task
 	getBytes, _ := json.MarshalIndent(getResp.Result, "", "  ")
 	fmt.Printf("get → \n%s\n", string(getBytes))
 
-	// 3. list: show every config attached to this task — should contain both.
+	// 3. list: show every config attached to this task - should contain both.
 	listResp, err := a2a.ListTaskPushNotificationConfig(ctx, types.ListTaskPushNotificationConfigParams{
 		Parent: taskID,
 	})

--- a/examples/usage-metadata/README.md
+++ b/examples/usage-metadata/README.md
@@ -20,8 +20,10 @@ This example demonstrates how to track and retrieve **token usage** and **execut
 - Automatic token usage tracking from LLM responses
 - Execution statistics collection (iterations, messages, tool calls)
 - Metadata population in completed task responses
-- Configuration options for enabling/disabling usage tracking
-- How to access usage data in both background and streaming tasks
+- How `A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA` toggles tracking on the
+  default task handlers (both background and streaming)
+- How to access usage data from both `message/send` (background) and
+  `message/stream` (streaming) flows
 
 ## Features
 
@@ -122,23 +124,38 @@ Usage metadata is automatically collected during task execution and populated in
 
 ### How It Works
 
-**For Background Tasks:**
+Both default task handlers honour the `EnableUsageMetadata` flag on
+`AgentConfig`. When you build the server with `WithDefaultBackgroundTaskHandler`,
+`WithDefaultStreamingTaskHandler`, or `WithDefaultTaskHandlers`, the builder
+wires the configured value through — so flipping the env var off truly disables
+metadata collection.
+
+**For Background Tasks (`message/send` + `tasks/get`):**
 
 ```go
 handler := server.NewDefaultBackgroundTaskHandler(logger, agent)
-// Usage metadata is automatically tracked and populated in Task.Metadata
+handler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
+// Usage metadata is populated in Task.Metadata when the task reaches
+// a terminal state (completed/failed/cancelled).
 ```
 
-**For Streaming Tasks:**
+**For Streaming Tasks (`message/stream`):**
 
 ```go
 handler := server.NewDefaultStreamingTaskHandler(logger, agent)
-// Usage metadata is tracked during streaming and available after completion
+handler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
+// Usage metadata is available on the final task snapshot once the
+// stream completes — fetch it via tasks/get after the stream ends.
 ```
 
 **In Your Code:**
 
-The `UsageTracker` is automatically injected into the agent execution context and collects metrics transparently. No additional code is required in your task handlers.
+The `UsageTracker` is automatically injected into the agent execution context and collects metrics transparently. No additional code is required in your task handlers — just set `A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA` (default `true`).
+
+The bundled client demonstrates both code paths: it submits three background
+tasks via `SendTask`/`GetTask`, then submits a final streaming task via
+`SendTaskStreaming` and re-fetches the completed task to display the metadata
+collected during the stream.
 
 ## Metadata Structure
 
@@ -197,7 +214,11 @@ Or in your `.env` file:
 A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA=false
 ```
 
-When disabled, the `Task.Metadata` field will not include usage information.
+When disabled, neither the background nor the streaming default handler will
+attach `usage` / `execution_stats` to `Task.Metadata`. To see the difference,
+start the server with the env var set to `false` and re-run the client — the
+"Usage Metadata" block printed by `displayUsageMetadata` will be empty (or
+absent) for every test case, both background and streaming.
 
 ## Use Cases
 

--- a/examples/usage-metadata/README.md
+++ b/examples/usage-metadata/README.md
@@ -150,7 +150,10 @@ handler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
 
 **In Your Code:**
 
-The `UsageTracker` is automatically injected into the agent execution context and collects metrics transparently. No additional code is required in your task handlers — just set `A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA` (default `true`).
+The `UsageTracker` is automatically injected into the agent execution context
+and collects metrics transparently. No additional code is required in your
+task handlers — just set `A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA` (default
+`true`).
 
 The bundled client demonstrates both code paths: it submits three background
 tasks via `SendTask`/`GetTask`, then submits a final streaming task via

--- a/examples/usage-metadata/README.md
+++ b/examples/usage-metadata/README.md
@@ -127,7 +127,7 @@ Usage metadata is automatically collected during task execution and populated in
 Both default task handlers honour the `EnableUsageMetadata` flag on
 `AgentConfig`. When you build the server with `WithDefaultBackgroundTaskHandler`,
 `WithDefaultStreamingTaskHandler`, or `WithDefaultTaskHandlers`, the builder
-wires the configured value through — so flipping the env var off truly disables
+wires the configured value through - so flipping the env var off truly disables
 metadata collection.
 
 **For Background Tasks (`message/send` + `tasks/get`):**
@@ -145,14 +145,14 @@ handler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
 handler := server.NewDefaultStreamingTaskHandler(logger, agent)
 handler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
 // Usage metadata is available on the final task snapshot once the
-// stream completes — fetch it via tasks/get after the stream ends.
+// stream completes - fetch it via tasks/get after the stream ends.
 ```
 
 **In Your Code:**
 
 The `UsageTracker` is automatically injected into the agent execution context
 and collects metrics transparently. No additional code is required in your
-task handlers — just set `A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA` (default
+task handlers - just set `A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA` (default
 `true`).
 
 The bundled client demonstrates both code paths: it submits three background
@@ -219,7 +219,7 @@ A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA=false
 
 When disabled, neither the background nor the streaming default handler will
 attach `usage` / `execution_stats` to `Task.Metadata`. To see the difference,
-start the server with the env var set to `false` and re-run the client — the
+start the server with the env var set to `false` and re-run the client - the
 "Usage Metadata" block printed by `displayUsageMetadata` will be empty (or
 absent) for every test case, both background and streaming.
 

--- a/examples/usage-metadata/client/main.go
+++ b/examples/usage-metadata/client/main.go
@@ -276,7 +276,7 @@ func runStreamingDemo(ctx context.Context, a2aClient client.A2AClient, logger *z
 	fmt.Printf(" done (%d events)\n", eventCount)
 
 	if taskID == "" {
-		fmt.Println("⚠ No task ID observed from stream — cannot fetch metadata")
+		fmt.Println("⚠ No task ID observed from stream - cannot fetch metadata")
 		return
 	}
 

--- a/examples/usage-metadata/client/main.go
+++ b/examples/usage-metadata/client/main.go
@@ -171,9 +171,146 @@ func main() {
 		}
 	}
 
+	// ────────────────────────────────────────────────────────────────
+	// Streaming demo: the EnableUsageMetadata flag also applies to the
+	// default streaming task handler. After the stream finishes, we
+	// fetch the final task snapshot and read Task.Metadata.
+	// ────────────────────────────────────────────────────────────────
+	fmt.Printf("\n┌─────────────────────────────────────────────────────┐\n")
+	fmt.Printf("│ Streaming Test: Usage Metadata via stream           │\n")
+	fmt.Printf("└─────────────────────────────────────────────────────┘\n")
+	runStreamingDemo(ctx, a2aClient, logger)
+
 	fmt.Println("\n═══════════════════════════════════════════════════════")
 	fmt.Println("All test cases completed!")
 	fmt.Println("═══════════════════════════════════════════════════════")
+	fmt.Println("Tip: re-run with A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA=false")
+	fmt.Println("on the server to confirm Task.Metadata is omitted.")
+	fmt.Println("═══════════════════════════════════════════════════════")
+}
+
+// runStreamingDemo submits a streaming task, consumes the event stream until
+// the task reaches a terminal state, then fetches the final task snapshot to
+// display the usage metadata captured by the streaming task handler.
+func runStreamingDemo(ctx context.Context, a2aClient client.A2AClient, logger *zap.Logger) {
+	prompt := "Calculate 7 * 6 using the calculate tool, then briefly explain the result."
+	fmt.Printf("Prompt: %s\n\n", prompt)
+
+	message := types.Message{
+		Role:  types.RoleUser,
+		Parts: []types.Part{types.NewTextPart(prompt)},
+	}
+
+	blocking := false
+	params := types.MessageSendParams{
+		Message: message,
+		Configuration: &types.MessageSendConfiguration{
+			Blocking:            &blocking,
+			AcceptedOutputModes: []string{"text/plain"},
+		},
+	}
+
+	eventChan, err := a2aClient.SendTaskStreaming(ctx, params)
+	if err != nil {
+		logger.Error("failed to start streaming task", zap.Error(err))
+		return
+	}
+
+	fmt.Print("Streaming")
+	var (
+		taskID       string
+		finalState   types.TaskState
+		eventCount   int
+		streamedText string
+	)
+
+	for event := range eventChan {
+		eventCount++
+		fmt.Print(".")
+
+		if event.Result == nil {
+			continue
+		}
+
+		resultBytes, err := json.Marshal(event.Result)
+		if err != nil {
+			continue
+		}
+
+		// Streaming events alternate between full Task snapshots and
+		// TaskStatusUpdateEvent entries. The wire payload carries a
+		// "kind" discriminator that isn't on the generated types yet, so
+		// peek at the raw JSON to route the decode.
+		var disc struct {
+			Kind string `json:"kind"`
+		}
+		_ = json.Unmarshal(resultBytes, &disc)
+
+		switch disc.Kind {
+		case "task":
+			var task types.Task
+			if err := json.Unmarshal(resultBytes, &task); err == nil {
+				if task.ID != "" {
+					taskID = task.ID
+				}
+				if task.Status.Message != nil {
+					for _, part := range task.Status.Message.Parts {
+						if part.Text != nil {
+							streamedText += *part.Text
+						}
+					}
+				}
+				finalState = task.Status.State
+			}
+		case "status-update":
+			var statusUpdate types.TaskStatusUpdateEvent
+			if err := json.Unmarshal(resultBytes, &statusUpdate); err == nil {
+				if statusUpdate.TaskID != "" {
+					taskID = statusUpdate.TaskID
+				}
+				finalState = statusUpdate.Status.State
+			}
+		}
+	}
+
+	fmt.Printf(" done (%d events)\n", eventCount)
+
+	if taskID == "" {
+		fmt.Println("⚠ No task ID observed from stream — cannot fetch metadata")
+		return
+	}
+
+	fmt.Printf("Task ID: %s\n", taskID)
+	fmt.Printf("Terminal state: %s\n", finalState)
+	if streamedText != "" {
+		fmt.Printf("Streamed response: %s\n", streamedText)
+	}
+
+	// Re-fetch the task to get the post-completion snapshot, which is where
+	// the default streaming handler writes the usage metadata.
+	taskResponse, err := a2aClient.GetTask(ctx, types.TaskQueryParams{ID: taskID})
+	if err != nil {
+		logger.Error("failed to fetch final task", zap.Error(err))
+		return
+	}
+
+	taskResultBytes, ok := taskResponse.Result.(json.RawMessage)
+	if !ok {
+		logger.Error("unexpected GetTask response shape")
+		return
+	}
+
+	var finalTask types.Task
+	if err := json.Unmarshal(taskResultBytes, &finalTask); err != nil {
+		logger.Error("failed to unmarshal final task", zap.Error(err))
+		return
+	}
+
+	var metadata map[string]any
+	if finalTask.Metadata != nil {
+		metadata = *finalTask.Metadata
+	}
+	displayUsageMetadata(metadata)
 }
 
 // displayUsageMetadata formats and displays the usage metadata from a task

--- a/server/server.go
+++ b/server/server.go
@@ -157,8 +157,12 @@ func NewA2AServer(cfg *config.Config, logger *zap.Logger, otel otel.OpenTelemetr
 
 	server.taskManager = NewDefaultTaskManagerWithStorage(logger, storage)
 	server.responseSender = NewDefaultResponseSender(logger)
-	server.backgroundTaskHandler = NewDefaultBackgroundTaskHandler(logger, server.agent)
-	server.streamingTaskHandler = NewDefaultStreamingTaskHandler(logger, server.agent)
+	bgHandler := NewDefaultBackgroundTaskHandler(logger, server.agent)
+	bgHandler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
+	server.backgroundTaskHandler = bgHandler
+	streamHandler := NewDefaultStreamingTaskHandler(logger, server.agent)
+	streamHandler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
+	server.streamingTaskHandler = streamHandler
 	server.protocolHandler = NewDefaultA2AProtocolHandler(
 		logger,
 		server.storage,
@@ -235,8 +239,12 @@ func NewA2AServerEnvironmentAware(cfg *config.Config, logger *zap.Logger, otel o
 
 	server.taskManager = NewDefaultTaskManagerWithStorage(logger, storage)
 	server.responseSender = NewDefaultResponseSender(logger)
-	server.backgroundTaskHandler = NewDefaultBackgroundTaskHandler(logger, server.agent)
-	server.streamingTaskHandler = NewDefaultStreamingTaskHandler(logger, server.agent)
+	bgHandler := NewDefaultBackgroundTaskHandler(logger, server.agent)
+	bgHandler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
+	server.backgroundTaskHandler = bgHandler
+	streamHandler := NewDefaultStreamingTaskHandler(logger, server.agent)
+	streamHandler.SetEnableUsageMetadata(cfg.AgentConfig.EnableUsageMetadata)
+	server.streamingTaskHandler = streamHandler
 	server.protocolHandler = NewDefaultA2AProtocolHandler(
 		logger,
 		server.storage,

--- a/server/server_builder.go
+++ b/server/server_builder.go
@@ -168,6 +168,7 @@ func (b *A2AServerBuilderImpl) WithDefaultBackgroundTaskHandler() A2AServerBuild
 	if b.artifactService != nil {
 		handler.artifactService = b.artifactService
 	}
+	handler.SetEnableUsageMetadata(b.cfg.AgentConfig.EnableUsageMetadata)
 	b.pollingTaskHandler = handler
 	return b
 }
@@ -178,6 +179,7 @@ func (b *A2AServerBuilderImpl) WithDefaultStreamingTaskHandler() A2AServerBuilde
 	if b.artifactService != nil {
 		handler.artifactService = b.artifactService
 	}
+	handler.SetEnableUsageMetadata(b.cfg.AgentConfig.EnableUsageMetadata)
 	b.streamingTaskHandler = handler
 	return b
 }
@@ -186,10 +188,12 @@ func (b *A2AServerBuilderImpl) WithDefaultStreamingTaskHandler() A2AServerBuilde
 func (b *A2AServerBuilderImpl) WithDefaultTaskHandlers() A2AServerBuilder {
 	bgHandler := NewDefaultBackgroundTaskHandler(b.logger, b.agent)
 	bgHandler.artifactService = b.artifactService
+	bgHandler.SetEnableUsageMetadata(b.cfg.AgentConfig.EnableUsageMetadata)
 	b.pollingTaskHandler = bgHandler
 
 	streamHandler := NewDefaultStreamingTaskHandler(b.logger, b.agent)
 	streamHandler.artifactService = b.artifactService
+	streamHandler.SetEnableUsageMetadata(b.cfg.AgentConfig.EnableUsageMetadata)
 	b.streamingTaskHandler = streamHandler
 	return b
 }

--- a/server/server_builder_test.go
+++ b/server/server_builder_test.go
@@ -189,6 +189,53 @@ func TestNewDefaultA2AServer(t *testing.T) {
 	assert.NotNil(t, a2aServer)
 }
 
+// TestA2AServerBuilder_UsageMetadataWiring confirms the EnableUsageMetadata
+// flag on AgentConfig is propagated to the default task handlers so that
+// callers can actually disable usage metadata via configuration.
+func TestA2AServerBuilder_UsageMetadataWiring(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "metadata enabled", enabled: true},
+		{name: "metadata disabled", enabled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				AgentName:    "test-agent",
+				ServerConfig: config.ServerConfig{Port: "8080"},
+				AgentConfig: config.AgentConfig{
+					// SystemPrompt ensures the config is not considered "empty"
+					// and overwritten with defaults by NewA2AServerBuilder.
+					SystemPrompt:                "You are a test assistant.",
+					MaxChatCompletionIterations: 10,
+					EnableUsageMetadata:         tt.enabled,
+				},
+				CapabilitiesConfig: config.CapabilitiesConfig{
+					Streaming: true,
+				},
+			}
+			logger := zap.NewNop()
+
+			a2aServer, err := server.NewA2AServerBuilder(cfg, logger).
+				WithDefaultTaskHandlers().
+				WithAgentCard(createTestAgentCard()).
+				Build()
+			require.NoError(t, err)
+
+			bg, ok := a2aServer.GetBackgroundTaskHandler().(*server.DefaultBackgroundTaskHandler)
+			require.True(t, ok, "expected DefaultBackgroundTaskHandler")
+			assert.Equal(t, tt.enabled, bg.IsUsageMetadataEnabled())
+
+			st, ok := a2aServer.GetStreamingTaskHandler().(*server.DefaultStreamingTaskHandler)
+			require.True(t, ok, "expected DefaultStreamingTaskHandler")
+			assert.Equal(t, tt.enabled, st.IsUsageMetadataEnabled())
+		})
+	}
+}
+
 func TestCustomA2AServer(t *testing.T) {
 	cfg := config.Config{
 		AgentName:    "custom-agent",

--- a/server/server_builder_test.go
+++ b/server/server_builder_test.go
@@ -4,13 +4,16 @@ import (
 	"testing"
 	"time"
 
-	server "github.com/inference-gateway/adk/server"
-	config "github.com/inference-gateway/adk/server/config"
-	mocks "github.com/inference-gateway/adk/server/mocks"
-	types "github.com/inference-gateway/adk/types"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
+
 	zap "go.uber.org/zap"
+
+	mocks "github.com/inference-gateway/adk/server/mocks"
+
+	server "github.com/inference-gateway/adk/server"
+	config "github.com/inference-gateway/adk/server/config"
+	types "github.com/inference-gateway/adk/types"
 )
 
 func TestA2AServerBuilder_BasicConstruction(t *testing.T) {
@@ -207,8 +210,6 @@ func TestA2AServerBuilder_UsageMetadataWiring(t *testing.T) {
 				AgentName:    "test-agent",
 				ServerConfig: config.ServerConfig{Port: "8080"},
 				AgentConfig: config.AgentConfig{
-					// SystemPrompt ensures the config is not considered "empty"
-					// and overwritten with defaults by NewA2AServerBuilder.
 					SystemPrompt:                "You are a test assistant.",
 					MaxChatCompletionIterations: 10,
 					EnableUsageMetadata:         tt.enabled,
@@ -462,7 +463,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 			URL:         new("http://test-agent:8080"),
 			Version:     "0.1.0",
 			Capabilities: types.AgentCapabilities{
-				Streaming:              new(false), // Streaming disabled, but still need background handler
+				Streaming:              new(false),
 				PushNotifications:      new(false),
 				StateTransitionHistory: new(false),
 			},
@@ -485,7 +486,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 			URL:         new("http://test-agent:8080"),
 			Version:     "0.1.0",
 			Capabilities: types.AgentCapabilities{
-				Streaming:              new(true), // Streaming enabled
+				Streaming:              new(true),
 				PushNotifications:      new(false),
 				StateTransitionHistory: new(false),
 			},
@@ -495,7 +496,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 
 		_, err := server.NewA2AServerBuilder(cfg, logger).
 			WithAgentCard(agentCard).
-			WithBackgroundTaskHandler(&mocks.FakeTaskHandler{}). // Only background handler
+			WithBackgroundTaskHandler(&mocks.FakeTaskHandler{}).
 			Build()
 
 		require.Error(t, err)
@@ -509,7 +510,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 			URL:         new("http://test-agent:8080"),
 			Version:     "0.1.0",
 			Capabilities: types.AgentCapabilities{
-				Streaming:              new(false), // Streaming disabled
+				Streaming:              new(false),
 				PushNotifications:      new(false),
 				StateTransitionHistory: new(false),
 			},
@@ -519,7 +520,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 
 		serverInstance, err := server.NewA2AServerBuilder(cfg, logger).
 			WithAgentCard(agentCard).
-			WithBackgroundTaskHandler(&mocks.FakeTaskHandler{}). // Only background handler is enough
+			WithBackgroundTaskHandler(&mocks.FakeTaskHandler{}).
 			Build()
 
 		require.NoError(t, err)
@@ -533,7 +534,7 @@ func TestA2AServerBuilder_Build_RequiresTaskHandlers(t *testing.T) {
 			URL:         new("http://test-agent:8080"),
 			Version:     "0.1.0",
 			Capabilities: types.AgentCapabilities{
-				Streaming:              new(true), // Streaming enabled
+				Streaming:              new(true),
 				PushNotifications:      new(false),
 				StateTransitionHistory: new(false),
 			},

--- a/server/task_handler.go
+++ b/server/task_handler.go
@@ -126,6 +126,19 @@ func (bth *DefaultBackgroundTaskHandler) GetAgent() OpenAICompatibleAgent {
 	return bth.agent
 }
 
+// SetEnableUsageMetadata toggles whether usage metadata (token counts and
+// execution statistics) is attached to the task's metadata when the task
+// reaches a terminal state.
+func (bth *DefaultBackgroundTaskHandler) SetEnableUsageMetadata(enabled bool) {
+	bth.enableUsageMetadata = enabled
+}
+
+// IsUsageMetadataEnabled reports whether the handler will attach usage
+// metadata to completed tasks.
+func (bth *DefaultBackgroundTaskHandler) IsUsageMetadataEnabled() bool {
+	return bth.enableUsageMetadata
+}
+
 // HandleTask processes a task with optimized logic for background scenarios
 func (bth *DefaultBackgroundTaskHandler) HandleTask(ctx context.Context, task *types.Task, message *types.Message) (*types.Task, error) {
 	if bth.agent != nil {
@@ -318,6 +331,19 @@ func (sth *DefaultStreamingTaskHandler) SetAgent(agent OpenAICompatibleAgent) {
 // GetAgent returns the configured agent
 func (sth *DefaultStreamingTaskHandler) GetAgent() OpenAICompatibleAgent {
 	return sth.agent
+}
+
+// SetEnableUsageMetadata toggles whether usage metadata (token counts and
+// execution statistics) is attached to the task's metadata when the task
+// reaches a terminal state.
+func (sth *DefaultStreamingTaskHandler) SetEnableUsageMetadata(enabled bool) {
+	sth.enableUsageMetadata = enabled
+}
+
+// IsUsageMetadataEnabled reports whether the handler will attach usage
+// metadata to completed tasks.
+func (sth *DefaultStreamingTaskHandler) IsUsageMetadataEnabled() bool {
+	return sth.enableUsageMetadata
 }
 
 // HandleStreamingTask processes a task and returns a channel of CloudEvents

--- a/server/usage_metadata_integration_test.go
+++ b/server/usage_metadata_integration_test.go
@@ -181,6 +181,139 @@ func TestUsageMetadata_StreamingTaskHandler(t *testing.T) {
 	assert.Greater(t, execStats["iterations"], 0, "Should have at least one iteration")
 }
 
+// TestUsageMetadata_BackgroundTaskHandler_Disabled verifies that when the
+// EnableUsageMetadata flag is false on the background handler, no usage
+// metadata is attached to the completed task.
+func TestUsageMetadata_BackgroundTaskHandler_Disabled(t *testing.T) {
+	logger := zap.NewNop()
+
+	mockLLMClient := &MockLLMClient{
+		streamResponses: []*sdk.CreateChatCompletionStreamResponse{
+			{
+				Choices: []sdk.ChatCompletionStreamChoice{
+					{
+						Delta: sdk.ChatCompletionStreamResponseDelta{
+							Content: "Disabled response.",
+						},
+					},
+				},
+			},
+			{
+				Choices: []sdk.ChatCompletionStreamChoice{
+					{
+						Delta:        sdk.ChatCompletionStreamResponseDelta{Content: ""},
+						FinishReason: "stop",
+					},
+				},
+				Usage: &sdk.CompletionUsage{
+					PromptTokens:     10,
+					CompletionTokens: 5,
+					TotalTokens:      15,
+				},
+			},
+		},
+	}
+
+	agent := NewOpenAICompatibleAgentWithConfig(logger, &config.AgentConfig{
+		MaxChatCompletionIterations: 10,
+		SystemPrompt:                "You are a test assistant",
+	})
+	agent.SetLLMClient(mockLLMClient)
+
+	handler := NewDefaultBackgroundTaskHandler(logger, agent)
+	require.True(t, handler.IsUsageMetadataEnabled(), "default should be enabled")
+	handler.SetEnableUsageMetadata(false)
+	require.False(t, handler.IsUsageMetadataEnabled(), "should be disabled after setter")
+
+	task := &types.Task{
+		ID:        "test-task-disabled",
+		ContextID: "test-context-disabled",
+		Status:    types.TaskStatus{State: types.TaskStateSubmitted},
+		History: []types.Message{
+			{
+				Role:  "user",
+				Parts: []types.Part{types.NewTextPart("Hello")},
+			},
+		},
+	}
+
+	resultTask, err := handler.HandleTask(context.Background(), task, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resultTask)
+
+	if resultTask.Metadata != nil {
+		assert.NotContains(t, *resultTask.Metadata, "usage", "usage metadata should not be attached when disabled")
+		assert.NotContains(t, *resultTask.Metadata, "execution_stats", "execution_stats should not be attached when disabled")
+	}
+}
+
+// TestUsageMetadata_StreamingTaskHandler_Disabled verifies the streaming
+// handler honors the disabled flag.
+func TestUsageMetadata_StreamingTaskHandler_Disabled(t *testing.T) {
+	logger := zap.NewNop()
+
+	mockLLMClient := &MockLLMClient{
+		streamResponses: []*sdk.CreateChatCompletionStreamResponse{
+			{
+				Choices: []sdk.ChatCompletionStreamChoice{
+					{
+						Delta: sdk.ChatCompletionStreamResponseDelta{Content: "Disabled streaming."},
+					},
+				},
+			},
+			{
+				Choices: []sdk.ChatCompletionStreamChoice{
+					{
+						Delta:        sdk.ChatCompletionStreamResponseDelta{Content: ""},
+						FinishReason: "stop",
+					},
+				},
+				Usage: &sdk.CompletionUsage{
+					PromptTokens:     20,
+					CompletionTokens: 10,
+					TotalTokens:      30,
+				},
+			},
+		},
+	}
+
+	agent := NewOpenAICompatibleAgentWithConfig(logger, &config.AgentConfig{
+		MaxChatCompletionIterations: 10,
+		SystemPrompt:                "You are a test assistant",
+	})
+	agent.SetLLMClient(mockLLMClient)
+
+	handler := NewDefaultStreamingTaskHandler(logger, agent)
+	require.True(t, handler.IsUsageMetadataEnabled(), "default should be enabled")
+	handler.SetEnableUsageMetadata(false)
+	require.False(t, handler.IsUsageMetadataEnabled(), "should be disabled after setter")
+
+	task := &types.Task{
+		ID:        "test-streaming-disabled",
+		ContextID: "test-streaming-context-disabled",
+		Status:    types.TaskStatus{State: types.TaskStateSubmitted},
+		History: []types.Message{
+			{
+				Role:  "user",
+				Parts: []types.Part{types.NewTextPart("Hello")},
+			},
+		},
+	}
+
+	eventChan, err := handler.HandleStreamingTask(context.Background(), task, nil)
+	require.NoError(t, err)
+	require.NotNil(t, eventChan)
+
+	for event := range eventChan {
+		_ = event
+	}
+
+	if task.Metadata != nil {
+		assert.NotContains(t, *task.Metadata, "usage", "usage metadata should not be attached when disabled")
+		assert.NotContains(t, *task.Metadata, "execution_stats", "execution_stats should not be attached when disabled")
+	}
+}
+
 // MockLLMClient is a simple mock for testing
 type MockLLMClient struct {
 	streamResponses []*sdk.CreateChatCompletionStreamResponse


### PR DESCRIPTION
Closes #154

## Summary

The usage-metadata feature (token usage + execution statistics attached to `Task.metadata` on completed tasks) was already implemented end-to-end in the codebase, including the `UsageTracker`, integration tests, and an `examples/usage-metadata/` client+server demo.

However, the `AgentConfig.EnableUsageMetadata` env var (`A2A_AGENT_CLIENT_ENABLE_USAGE_METADATA`) was defined and documented but never read - both default task handlers hardcoded `enableUsageMetadata: true` with no setter, so setting the env var to `false` had no effect.

## Changes

- Add `SetEnableUsageMetadata(bool)` / `IsUsageMetadataEnabled()` to `DefaultBackgroundTaskHandler` and `DefaultStreamingTaskHandler`.
- Wire `cfg.AgentConfig.EnableUsageMetadata` through `WithDefaultBackgroundTaskHandler`, `WithDefaultStreamingTaskHandler`, `WithDefaultTaskHandlers`, `NewA2AServer`, and `NewA2AServerEnvironmentAware`.
- Add integration tests covering the disabled path for both handler types and a builder test asserting the flag round-trips for enabled/disabled values.

## A2A protocol compliance

`Task.metadata` is a free-form `Struct` per `schema.yaml:1003-1007`, so attaching custom `usage` / `execution_stats` keys there is spec-compliant. Metadata is only attached on terminal states (`completed` / `failed` / `cancelled`).

## Follow-up

A `[FEATURE]` issue draft for `inference-gateway/cli` to display this metadata is included in the issue #154 comment thread - file manually when ready.

🤖 Generated with [Claude Code](https://claude.ai/code)