### PR TITLE
ci: restrict default workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to workflows that omitted one, so the default `GITHUB_TOKEN` carries only the scope the workflow needs. Jobs that declare their own `permissions:` block are unaffected (job-level blocks override the top-level one), and the org default token is already read-only, so this is behavior-preserving.

Refs inference-gateway/.github#96