### PR TITLE
fix(otel): propagate trace context into background task processing

### DIFF
--- a/server/mocks/fake_storage.go
+++ b/server/mocks/fake_storage.go
@@ -99,11 +99,12 @@ type FakeStorage struct {
 		result1 *server.QueuedTask
 		result2 error
 	}
-	EnqueueTaskStub        func(*types.Task, any) error
+	EnqueueTaskStub        func(context.Context, *types.Task, any) error
 	enqueueTaskMutex       sync.RWMutex
 	enqueueTaskArgsForCall []struct {
-		arg1 *types.Task
-		arg2 any
+		arg1 context.Context
+		arg2 *types.Task
+		arg3 any
 	}
 	enqueueTaskReturns struct {
 		result1 error
@@ -720,19 +721,20 @@ func (fake *FakeStorage) DequeueTaskReturnsOnCall(i int, result1 *server.QueuedT
 	}{result1, result2}
 }
 
-func (fake *FakeStorage) EnqueueTask(arg1 *types.Task, arg2 any) error {
+func (fake *FakeStorage) EnqueueTask(arg1 context.Context, arg2 *types.Task, arg3 any) error {
 	fake.enqueueTaskMutex.Lock()
 	ret, specificReturn := fake.enqueueTaskReturnsOnCall[len(fake.enqueueTaskArgsForCall)]
 	fake.enqueueTaskArgsForCall = append(fake.enqueueTaskArgsForCall, struct {
-		arg1 *types.Task
-		arg2 any
-	}{arg1, arg2})
+		arg1 context.Context
+		arg2 *types.Task
+		arg3 any
+	}{arg1, arg2, arg3})
 	stub := fake.EnqueueTaskStub
 	fakeReturns := fake.enqueueTaskReturns
-	fake.recordInvocation("EnqueueTask", []interface{}{arg1, arg2})
+	fake.recordInvocation("EnqueueTask", []interface{}{arg1, arg2, arg3})
 	fake.enqueueTaskMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -746,17 +748,17 @@ func (fake *FakeStorage) EnqueueTaskCallCount() int {
 	return len(fake.enqueueTaskArgsForCall)
 }
 
-func (fake *FakeStorage) EnqueueTaskCalls(stub func(*types.Task, any) error) {
+func (fake *FakeStorage) EnqueueTaskCalls(stub func(context.Context, *types.Task, any) error) {
 	fake.enqueueTaskMutex.Lock()
 	defer fake.enqueueTaskMutex.Unlock()
 	fake.EnqueueTaskStub = stub
 }
 
-func (fake *FakeStorage) EnqueueTaskArgsForCall(i int) (*types.Task, any) {
+func (fake *FakeStorage) EnqueueTaskArgsForCall(i int) (context.Context, *types.Task, any) {
 	fake.enqueueTaskMutex.RLock()
 	defer fake.enqueueTaskMutex.RUnlock()
 	argsForCall := fake.enqueueTaskArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeStorage) EnqueueTaskReturns(result1 error) {

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,9 @@ import (
 	types "github.com/inference-gateway/adk/types"
 	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
 	envconfig "github.com/sethvargo/go-envconfig"
+	sdkotel "go.opentelemetry.io/otel"
+	attribute "go.opentelemetry.io/otel/attribute"
+	trace "go.opentelemetry.io/otel/trace"
 	zap "go.uber.org/zap"
 )
 
@@ -582,6 +585,11 @@ func (s *A2AServerImpl) StartTaskProcessor(ctx context.Context) {
 // processQueuedTask processes a single queued task
 func (s *A2AServerImpl) processQueuedTask(ctx context.Context, queuedTask *QueuedTask) {
 	task := queuedTask.Task
+
+	ctx = extractTraceContext(ctx, queuedTask.TraceContext)
+	ctx, span := sdkotel.Tracer("github.com/inference-gateway/adk/server").Start(ctx, "task.process",
+		trace.WithAttributes(attribute.String("a2a.task.id", task.ID)))
+	defer span.End()
 
 	var message *types.Message
 	if task.Status.Message != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -95,7 +95,7 @@ func TestA2AServer_TaskManager_GetTask(t *testing.T) {
 	}
 	task := taskManager.CreateTask("test-context", types.TaskStateSubmitted, message)
 
-	err := taskManager.GetStorage().EnqueueTask(task, "test-request-id")
+	err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id")
 	assert.NoError(t, err)
 
 	retrievedTask, exists := taskManager.GetTask(task.ID)

--- a/server/storage.go
+++ b/server/storage.go
@@ -6,20 +6,46 @@ import (
 	"sync"
 
 	types "github.com/inference-gateway/adk/types"
+	otel "go.opentelemetry.io/otel"
+	propagation "go.opentelemetry.io/otel/propagation"
 	zap "go.uber.org/zap"
 )
+
+// injectTraceContext serializes the trace context and baggage from ctx into a
+// map suitable for storing on a QueuedTask. Returns nil when there is nothing
+// to propagate.
+func injectTraceContext(ctx context.Context) map[string]string {
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+	if len(carrier) == 0 {
+		return nil
+	}
+	return carrier
+}
+
+// extractTraceContext restores a trace context previously captured by
+// injectTraceContext onto ctx.
+func extractTraceContext(ctx context.Context, traceContext map[string]string) context.Context {
+	if len(traceContext) == 0 {
+		return ctx
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(traceContext))
+}
 
 // QueuedTask represents a task in the processing queue
 type QueuedTask struct {
 	Task      *types.Task
 	RequestID any
+	// TraceContext carries the W3C trace context and baggage of the request
+	// that enqueued the task, so background processing joins the caller's trace.
+	TraceContext map[string]string `json:"trace_context,omitempty"`
 }
 
 // Storage defines the interface for queue-centric task management
 // Tasks carry their complete message history and flow through: Queue -> Processing -> Dead Letter
 type Storage interface {
 	// Task Queue Management (primary storage for active tasks)
-	EnqueueTask(task *types.Task, requestID any) error
+	EnqueueTask(ctx context.Context, task *types.Task, requestID any) error
 	DequeueTask(ctx context.Context) (*QueuedTask, error)
 	GetQueueLength() int
 	ClearQueue() error
@@ -723,14 +749,15 @@ func (s *InMemoryStorage) GetStats() StorageStats {
 }
 
 // EnqueueTask adds a task to the processing queue
-func (s *InMemoryStorage) EnqueueTask(task *types.Task, requestID any) error {
+func (s *InMemoryStorage) EnqueueTask(ctx context.Context, task *types.Task, requestID any) error {
 	if task == nil {
 		return fmt.Errorf("task cannot be nil")
 	}
 
 	queuedTask := &QueuedTask{
-		Task:      task,
-		RequestID: requestID,
+		Task:         task,
+		RequestID:    requestID,
+		TraceContext: injectTraceContext(ctx),
 	}
 
 	s.queueMu.Lock()

--- a/server/storage_extensibility_test.go
+++ b/server/storage_extensibility_test.go
@@ -30,7 +30,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					},
 				}
 
-				err := storage.EnqueueTask(task, "request-1")
+				err := storage.EnqueueTask(context.Background(), task, "request-1")
 				require.NoError(t, err)
 
 				err = storage.UpdateActiveTask(task)
@@ -82,7 +82,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					},
 				}
 
-				err := storage.EnqueueTask(task, "request-3")
+				err := storage.EnqueueTask(context.Background(), task, "request-3")
 				require.NoError(t, err)
 
 				err = storage.UpdateActiveTask(task)
@@ -113,7 +113,7 @@ func TestQueueCentricOperations(t *testing.T) {
 					},
 				}
 
-				err := storage.EnqueueTask(task, "request-4")
+				err := storage.EnqueueTask(context.Background(), task, "request-4")
 				require.NoError(t, err)
 
 				length = storage.GetQueueLength()
@@ -171,7 +171,7 @@ func TestQueueCentricOperations(t *testing.T) {
 						State: types.TaskStateSubmitted,
 					},
 				}
-				err := storage.EnqueueTask(activeTask, "request-active")
+				err := storage.EnqueueTask(context.Background(), activeTask, "request-active")
 				require.NoError(t, err)
 				err = storage.UpdateActiveTask(activeTask)
 				require.NoError(t, err)

--- a/server/storage_queue_test.go
+++ b/server/storage_queue_test.go
@@ -26,7 +26,7 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 	}
 
 	t.Run("Enqueue and Dequeue Task", func(t *testing.T) {
-		err := storage.EnqueueTask(task, "request-123")
+		err := storage.EnqueueTask(context.Background(), task, "request-123")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -61,11 +61,11 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 		task2 := &types.Task{ID: "task-2", ContextID: "ctx-2", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
 		task3 := &types.Task{ID: "task-3", ContextID: "ctx-3", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
 
-		err := storage.EnqueueTask(task1, "req-1")
+		err := storage.EnqueueTask(context.Background(), task1, "req-1")
 		require.NoError(t, err)
-		err = storage.EnqueueTask(task2, "req-2")
+		err = storage.EnqueueTask(context.Background(), task2, "req-2")
 		require.NoError(t, err)
-		err = storage.EnqueueTask(task3, "req-3")
+		err = storage.EnqueueTask(context.Background(), task3, "req-3")
 		require.NoError(t, err)
 
 		if length := storage.GetQueueLength(); length != 3 {
@@ -110,9 +110,9 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 		task1 := &types.Task{ID: "clear-task-1", ContextID: "ctx", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
 		task2 := &types.Task{ID: "clear-task-2", ContextID: "ctx", Status: types.TaskStatus{State: types.TaskStateSubmitted}}
 
-		err := storage.EnqueueTask(task1, "req-1")
+		err := storage.EnqueueTask(context.Background(), task1, "req-1")
 		require.NoError(t, err)
-		err = storage.EnqueueTask(task2, "req-2")
+		err = storage.EnqueueTask(context.Background(), task2, "req-2")
 		require.NoError(t, err)
 
 		if length := storage.GetQueueLength(); length != 2 {
@@ -128,7 +128,7 @@ func TestInMemoryStorage_QueueOperations(t *testing.T) {
 	})
 
 	t.Run("Enqueue Nil Task", func(t *testing.T) {
-		err := storage.EnqueueTask(nil, "req-123")
+		err := storage.EnqueueTask(context.Background(), nil, "req-123")
 		if err == nil {
 			t.Fatalf("expected error for nil task, got nil")
 		}
@@ -167,7 +167,7 @@ func TestInMemoryStorage_ConcurrentQueueOperations(t *testing.T) {
 						ContextID: "concurrent-test",
 						Status:    types.TaskStatus{State: types.TaskStateSubmitted},
 					}
-					err := storage.EnqueueTask(task, fmt.Sprintf("req-%d-%d", i, j))
+					err := storage.EnqueueTask(context.Background(), task, fmt.Sprintf("req-%d-%d", i, j))
 					if err != nil {
 						t.Errorf("enqueue error: %v", err)
 						return

--- a/server/storage_redis.go
+++ b/server/storage_redis.go
@@ -136,16 +136,15 @@ const (
 )
 
 // EnqueueTask adds a task to the processing queue
-func (s *RedisStorage) EnqueueTask(task *types.Task, requestID any) error {
-	ctx := context.Background()
-
+func (s *RedisStorage) EnqueueTask(ctx context.Context, task *types.Task, requestID any) error {
 	if task == nil {
 		return fmt.Errorf("task cannot be nil")
 	}
 
 	queuedTask := &QueuedTask{
-		Task:      task,
-		RequestID: requestID,
+		Task:         task,
+		RequestID:    requestID,
+		TraceContext: injectTraceContext(ctx),
 	}
 
 	data, err := json.Marshal(queuedTask)

--- a/server/storage_redis_test.go
+++ b/server/storage_redis_test.go
@@ -80,7 +80,7 @@ func TestRedisStorageEnqueueTask(t *testing.T) {
 	fakeClient.PublishReturns(redis.NewIntResult(1, nil))
 	fakeClient.LLenReturns(redis.NewIntResult(1, nil))
 
-	require.NoError(t, storage.EnqueueTask(task, "request-123"))
+	require.NoError(t, storage.EnqueueTask(context.Background(), task, "request-123"))
 
 	require.Equal(t, 1, fakePipe.LPushCallCount())
 	_, gotQueueKey, gotQueueValues := fakePipe.LPushArgsForCall(0)
@@ -110,7 +110,7 @@ func TestRedisStorageEnqueueTask(t *testing.T) {
 
 func TestRedisStorageEnqueueNilTask(t *testing.T) {
 	storage, _, _ := newTestRedisStorage(t)
-	err := storage.EnqueueTask(nil, "request-1")
+	err := storage.EnqueueTask(context.Background(), nil, "request-1")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "task cannot be nil")
 }
@@ -119,7 +119,7 @@ func TestRedisStorageEnqueueTaskPipelineExecError(t *testing.T) {
 	storage, _, fakePipe := newTestRedisStorage(t)
 	fakePipe.ExecReturns(nil, errors.New("boom"))
 
-	err := storage.EnqueueTask(&types.Task{ID: "t", ContextID: "c"}, "r")
+	err := storage.EnqueueTask(context.Background(), &types.Task{ID: "t", ContextID: "c"}, "r")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to enqueue task")
 }

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -24,7 +24,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 			History:   []types.Message{},
 		}
 
-		err := storage.EnqueueTask(task, "request-1")
+		err := storage.EnqueueTask(context.Background(), task, "request-1")
 		assert.NoError(t, err)
 
 		ctx := context.Background()
@@ -44,7 +44,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 			History:   []types.Message{},
 		}
 
-		err := storage.EnqueueTask(task, "request-2")
+		err := storage.EnqueueTask(context.Background(), task, "request-2")
 		assert.NoError(t, err)
 
 		retrievedTask, err := storage.GetActiveTask("task-2")
@@ -97,7 +97,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 			History:   []types.Message{},
 		}
 
-		err := storage.EnqueueTask(workingTask, "request-working")
+		err := storage.EnqueueTask(context.Background(), workingTask, "request-working")
 		assert.NoError(t, err)
 
 		err = storage.StoreDeadLetterTask(completedTask)
@@ -131,7 +131,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 				History:   []types.Message{},
 			}
 
-			err := freshStorage.EnqueueTask(task, fmt.Sprintf("request-%d", i))
+			err := freshStorage.EnqueueTask(context.Background(), task, fmt.Sprintf("request-%d", i))
 			assert.NoError(t, err)
 		}
 
@@ -168,7 +168,7 @@ func TestInMemoryStorage_QueueCentricOperations(t *testing.T) {
 			History:   []types.Message{},
 		}
 
-		err := storage.EnqueueTask(task1, "request-alpha")
+		err := storage.EnqueueTask(context.Background(), task1, "request-alpha")
 		assert.NoError(t, err)
 
 		err = storage.StoreDeadLetterTask(task2)

--- a/server/task_handler.go
+++ b/server/task_handler.go
@@ -516,7 +516,7 @@ func (h *DefaultA2AProtocolHandler) HandleMessageSend(c *gin.Context, req types.
 		return
 	}
 
-	err = h.storage.EnqueueTask(task, req.ID)
+	err = h.storage.EnqueueTask(c.Request.Context(), task, req.ID)
 	if err != nil {
 		h.logger.Error("failed to enqueue task", zap.Error(err))
 		err := h.taskManager.UpdateError(task.ID, &types.Message{

--- a/server/task_manager_test.go
+++ b/server/task_manager_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -115,7 +116,7 @@ func TestDefaultTaskManager_GetTask(t *testing.T) {
 
 	createdTask := taskManager.CreateTask("test-context", types.TaskStateSubmitted, message)
 
-	err := taskManager.GetStorage().EnqueueTask(createdTask, "test-request-id")
+	err := taskManager.GetStorage().EnqueueTask(context.Background(), createdTask, "test-request-id")
 	assert.NoError(t, err)
 
 	retrievedTask, exists := taskManager.GetTask(createdTask.ID)
@@ -144,13 +145,13 @@ func TestDefaultTaskManager_CleanupCompletedTasks(t *testing.T) {
 	failedTask := taskManager.CreateTask("context-4", types.TaskStateFailed, nil)
 
 	storage := taskManager.GetStorage()
-	err := storage.EnqueueTask(submittedTask, "req-1")
+	err := storage.EnqueueTask(context.Background(), submittedTask, "req-1")
 	assert.NoError(t, err)
-	err = storage.EnqueueTask(workingTask, "req-2")
+	err = storage.EnqueueTask(context.Background(), workingTask, "req-2")
 	assert.NoError(t, err)
-	err = storage.EnqueueTask(completedTask, "req-3")
+	err = storage.EnqueueTask(context.Background(), completedTask, "req-3")
 	assert.NoError(t, err)
-	err = storage.EnqueueTask(failedTask, "req-4")
+	err = storage.EnqueueTask(context.Background(), failedTask, "req-4")
 	assert.NoError(t, err)
 
 	_, exists := taskManager.GetTask(submittedTask.ID)
@@ -673,7 +674,7 @@ func TestDefaultTaskManager_CancelTask_StateValidation(t *testing.T) {
 				},
 			})
 
-			err := taskManager.GetStorage().EnqueueTask(task, "test-request-id")
+			err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id")
 			assert.NoError(t, err)
 
 			err = taskManager.CancelTask(task.ID)
@@ -709,7 +710,7 @@ func TestDefaultTaskManager_PauseTaskForInput(t *testing.T) {
 			},
 		})
 
-		err := taskManager.GetStorage().EnqueueTask(task, "test-request-id")
+		err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id")
 		assert.NoError(t, err)
 
 		pauseMessage := &types.Message{
@@ -735,7 +736,7 @@ func TestDefaultTaskManager_PauseTaskForInput(t *testing.T) {
 	t.Run("pause with nil message", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context-2", types.TaskStateWorking, nil)
 
-		err := taskManager.GetStorage().EnqueueTask(task, "test-request-id-2")
+		err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id-2")
 		assert.NoError(t, err)
 
 		err = taskManager.PauseTaskForInput(task.ID, nil)
@@ -761,7 +762,7 @@ func TestDefaultTaskManager_ResumeTaskWithInput(t *testing.T) {
 	t.Run("resume paused task successfully", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateWorking, nil)
 
-		err := taskManager.GetStorage().EnqueueTask(task, "test-request-id")
+		err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id")
 		assert.NoError(t, err)
 
 		err = taskManager.PauseTaskForInput(task.ID, nil)
@@ -790,7 +791,7 @@ func TestDefaultTaskManager_ResumeTaskWithInput(t *testing.T) {
 	t.Run("resume task in non-completed state should succeed", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context-2", types.TaskStateWorking, nil)
 
-		err := taskManager.GetStorage().EnqueueTask(task, "test-request-id-2")
+		err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id-2")
 		assert.NoError(t, err)
 
 		err = taskManager.ResumeTaskWithInput(task.ID, nil)
@@ -804,7 +805,7 @@ func TestDefaultTaskManager_ResumeTaskWithInput(t *testing.T) {
 	t.Run("resume completed task should fail", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context-3", types.TaskStateCompleted, nil)
 
-		err := taskManager.GetStorage().EnqueueTask(task, "test-request-id-3")
+		err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id-3")
 		assert.NoError(t, err)
 
 		err = taskManager.ResumeTaskWithInput(task.ID, nil)
@@ -827,7 +828,7 @@ func TestDefaultTaskManager_IsTaskPaused(t *testing.T) {
 	t.Run("check paused task", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateWorking, nil)
 
-		err := taskManager.GetStorage().EnqueueTask(task, "test-request-id")
+		err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id")
 		assert.NoError(t, err)
 
 		isPaused, err := taskManager.IsTaskPaused(task.ID)
@@ -857,7 +858,7 @@ func TestDefaultTaskManager_PollTaskStatus_InputRequired(t *testing.T) {
 	t.Run("polling returns when task reaches input-required state", func(t *testing.T) {
 		task := taskManager.CreateTask("test-context", types.TaskStateWorking, nil)
 
-		err := taskManager.GetStorage().EnqueueTask(task, "test-request-id")
+		err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id")
 		assert.NoError(t, err)
 
 		resultChan := make(chan *types.Task, 1)
@@ -901,7 +902,7 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 	}
 	task := taskManager.CreateTask("test-context", types.TaskStateWorking, initialMessage)
 
-	err := taskManager.GetStorage().EnqueueTask(task, "test-request-id")
+	err := taskManager.GetStorage().EnqueueTask(context.Background(), task, "test-request-id")
 	assert.NoError(t, err)
 
 	pauseMessage := &types.Message{
@@ -923,7 +924,7 @@ func TestDefaultTaskManager_InputRequiredWorkflow(t *testing.T) {
 
 	task2 := taskManager.CreateTask("test-context-2", types.TaskStateWorking, initialMessage)
 
-	err = taskManager.GetStorage().EnqueueTask(task2, "test-request-id-2")
+	err = taskManager.GetStorage().EnqueueTask(context.Background(), task2, "test-request-id-2")
 	assert.NoError(t, err)
 
 	err = taskManager.PauseTaskForInput(task2.ID, pauseMessage)

--- a/server/trace_propagation_test.go
+++ b/server/trace_propagation_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	types "github.com/inference-gateway/adk/types"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+	otel "go.opentelemetry.io/otel"
+	propagation "go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	trace "go.opentelemetry.io/otel/trace"
+	zap "go.uber.org/zap"
+)
+
+// TestTraceContextPropagation verifies that the trace context of the request
+// that enqueued a task survives the queue (including a JSON round-trip, as in
+// the Redis storage) and is restored for background processing.
+func TestTraceContextPropagation(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	tracerProvider := sdktrace.NewTracerProvider()
+	ctx, span := tracerProvider.Tracer("test").Start(context.Background(), "a2a.request")
+	defer span.End()
+	wantTraceID := span.SpanContext().TraceID()
+
+	t.Run("inject and extract round-trip", func(t *testing.T) {
+		carrier := injectTraceContext(ctx)
+		require.NotEmpty(t, carrier)
+		assert.Contains(t, carrier, "traceparent")
+
+		restored := extractTraceContext(context.Background(), carrier)
+		assert.Equal(t, wantTraceID, trace.SpanContextFromContext(restored).TraceID())
+	})
+
+	t.Run("empty context yields nil carrier and no-op extract", func(t *testing.T) {
+		assert.Nil(t, injectTraceContext(context.Background()))
+		base := context.Background()
+		assert.Equal(t, base, extractTraceContext(base, nil))
+	})
+
+	t.Run("survives storage enqueue/dequeue and JSON round-trip", func(t *testing.T) {
+		storage := NewInMemoryStorage(zap.NewNop(), 10)
+		task := &types.Task{
+			ID:        "task-trace",
+			ContextID: "context-trace",
+			Status:    types.TaskStatus{State: types.TaskStateSubmitted},
+		}
+		require.NoError(t, storage.EnqueueTask(ctx, task, "req-trace"))
+
+		queued, err := storage.DequeueTask(context.Background())
+		require.NoError(t, err)
+		require.NotEmpty(t, queued.TraceContext)
+
+		data, err := json.Marshal(queued)
+		require.NoError(t, err)
+		var roundTripped QueuedTask
+		require.NoError(t, json.Unmarshal(data, &roundTripped))
+
+		restored := extractTraceContext(context.Background(), roundTripped.TraceContext)
+		assert.Equal(t, wantTraceID, trace.SpanContextFromContext(restored).TraceID())
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #235 — tool spans emitted during background task processing started a brand-new root trace instead of joining the caller's propagated trace.

The telemetry middleware correctly extracts `traceparent` + baggage and starts `a2a.request`, but `message/send` enqueues the task and returns; the processor loop runs off the server-lifetime context, so the handler (and any `startToolSpan`-style spans under it) got an empty parent.

## Changes

- `QueuedTask` gains a `TraceContext map[string]string` field — the propagation context (trace context + baggage, via the already-configured composite propagator) is injected at enqueue and survives the Redis JSON round-trip.
- `Storage.EnqueueTask` now takes a `context.Context` first argument; `HandleMessageSend` passes the request context.
- `processQueuedTask` restores the trace context and wraps processing in a `task.process` span (`a2a.task.id` attribute), yielding the expected tree: `execute_tool A2A_SubmitTask → a2a.request → task.process → tool.*`.
- Regenerated `server/mocks/fake_storage.go`; new `server/trace_propagation_test.go` covering inject/extract round-trip, empty-context no-op, and enqueue→dequeue→JSON survival.

## Ecosystem

No new config surface — internal telemetry behavior only, so no docs ticket needed. Downstream: agents regenerated against this release (e.g. mock-agent) pick up nested tool spans automatically; verified end-to-end plan via inference-gateway/cli#909's `examples/a2a-traces`.

Closes #235
