### PR TITLE
fix(otel): append signal path to path-less OTLP HTTP endpoint URLs

### DIFF
--- a/server/otel/otel.go
+++ b/server/otel/otel.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	otel "go.opentelemetry.io/otel"
 	attribute "go.opentelemetry.io/otel/attribute"
@@ -191,6 +192,22 @@ func (o *OpenTelemetryImpl) initializeMetrics(cfg *config.Config, res *sdkresour
 	return nil
 }
 
+// SignalEndpointURL appends the OTLP signal path (e.g. "v1/traces") to a
+// path-less HTTP endpoint URL. otel-go 1.45.0 stopped appending the default
+// signal path in the HTTP exporters' WithEndpointURL, so a bare endpoint like
+// http://localhost:4318 would silently export to "/" instead.
+func SignalEndpointURL(endpoint, signalPath string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil || (u.Path != "" && u.Path != "/") {
+		return endpoint
+	}
+	joined, err := url.JoinPath(endpoint, signalPath)
+	if err != nil {
+		return endpoint
+	}
+	return joined
+}
+
 // newOTLPMetricExporter builds an OTLP metric exporter for the resolved protocol.
 func (o *OpenTelemetryImpl) newOTLPMetricExporter(resolved config.ResolvedTelemetry) (sdkmetric.Exporter, error) {
 	ctx := context.Background()
@@ -204,7 +221,7 @@ func (o *OpenTelemetryImpl) newOTLPMetricExporter(resolved config.ResolvedTeleme
 
 	httpOpts := []otlpmetrichttp.Option{}
 	if resolved.OTLPEndpoint != "" {
-		httpOpts = append(httpOpts, otlpmetrichttp.WithEndpointURL(resolved.OTLPEndpoint))
+		httpOpts = append(httpOpts, otlpmetrichttp.WithEndpointURL(SignalEndpointURL(resolved.OTLPEndpoint, "v1/metrics")))
 	}
 	return otlpmetrichttp.New(ctx, httpOpts...)
 }
@@ -257,7 +274,7 @@ func (o *OpenTelemetryImpl) newOTLPTraceExporter(cfg *config.Config, resolved co
 
 	httpOpts := []otlptracehttp.Option{}
 	if resolved.OTLPEndpoint != "" {
-		httpOpts = append(httpOpts, otlptracehttp.WithEndpointURL(resolved.OTLPEndpoint))
+		httpOpts = append(httpOpts, otlptracehttp.WithEndpointURL(SignalEndpointURL(resolved.OTLPEndpoint, "v1/traces")))
 	}
 	if len(headers) > 0 {
 		httpOpts = append(httpOpts, otlptracehttp.WithHeaders(headers))

--- a/server/otel/otel_test.go
+++ b/server/otel/otel_test.go
@@ -76,3 +76,16 @@ func TestNewOpenTelemetry_Exporters(t *testing.T) {
 		})
 	}
 }
+
+func TestSignalEndpointURL(t *testing.T) {
+	cases := map[string]string{
+		"http://localhost:4318":           "http://localhost:4318/v1/traces",
+		"http://172.17.0.1:4318/":         "http://172.17.0.1:4318/v1/traces",
+		"http://collector:4318/v1/traces": "http://collector:4318/v1/traces",
+		"https://otlp.example.com/custom": "https://otlp.example.com/custom",
+	}
+	for in, want := range cases {
+		require.Equal(t, want, adkotel.SignalEndpointURL(in, "v1/traces"))
+	}
+	require.Equal(t, "http://localhost:4318/v1/metrics", adkotel.SignalEndpointURL("http://localhost:4318", "v1/metrics"))
+}


### PR DESCRIPTION
## Problem

#278 bumped otel-go to v1.45.0, which includes an upstream breaking change (open-telemetry/opentelemetry-go#8538): the HTTP exporters' `WithEndpointURL` no longer appends the default signal path when the endpoint URL has no path — it posts to `/` instead.

Agents configured with a bare endpoint like `A2A_OTEL_EXPORTER_OTLP_ENDPOINT=http://172.17.0.1:4318` (exactly what infer-action passes) would silently export traces and metrics to `/`, so `a2a.request` sub-spans would vanish from distributed traces. Not yet in any release — v0.26.2 predates the bump — but the next release would ship it. Same bug already fixed in the gateway: inference-gateway/inference-gateway#555.

## Fix

`SignalEndpointURL` appends `v1/traces` / `v1/metrics` when the configured HTTP endpoint has no path (or only `/`), restoring pre-1.45 behavior. Endpoints with an explicit path pass through unchanged; gRPC exporters are unaffected (no signal path concept).

## Testing

- `TestSignalEndpointURL` covers bare, trailing-slash, already-suffixed, and custom-path endpoints for both signals
- `go test ./server/...` passes